### PR TITLE
Fix dropping default ValueTask

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -27,6 +27,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
     private const string IAsyncEnumerator = "System.Collections.Generic.IAsyncEnumerator";
     private const string FromResult = "FromResult";
     private const string Delay = "Delay";
+    private const string CompletedTask = "CompletedTask";
     private static readonly HashSet<string> Drops = [IProgressInterface, CancellationTokenType];
     private static readonly HashSet<string> InterfacesToDrop = [IProgressInterface, IAsyncResultInterface];
     private static readonly Dictionary<string, string?> Replacements = new()
@@ -1178,7 +1179,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
 
     private static bool ShouldRemoveArgument(ISymbol symbol) => symbol switch
     {
-        IPropertySymbol { Name: "CompletedTask" } ps => ps.Type.ToString() is TaskType or ValueTaskType,
+        IPropertySymbol { Name: CompletedTask } ps => ps.Type.ToString() is TaskType or ValueTaskType,
         IMethodSymbol ms =>
             IsSpecialMethod(ms) == SpecialMethod.None
                 && ((ShouldRemoveType(ms.ReturnType) && ms.MethodKind != MethodKind.LocalFunction)

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1526,7 +1526,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
 
     private bool ShouldRemoveLiteral(LiteralExpressionSyntax literalExpression)
         => literalExpression.Token.IsKind(SyntaxKind.DefaultKeyword)
-           && semanticModel.GetTypeInfo(literalExpression).Type is { Name: "ValueTask" };
+           && semanticModel.GetTypeInfo(literalExpression).Type is INamedTypeSymbol { Name: "ValueTask", IsGenericType: false };
 
     /// <summary>
     /// Keeps track of nested directives.

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1158,7 +1158,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
 
     private static bool ShouldRemoveArgument(ISymbol symbol) => symbol switch
     {
-        IPropertySymbol { Name: "CompletedTask", ContainingType.Name: "Task" or "ValueTask" } => true,
+        IPropertySymbol { Name: "CompletedTask" } ps => ps.Type.ToString() is TaskType or ValueTaskType,
         IMethodSymbol ms =>
             IsSpecialMethod(ms) == SpecialMethod.None
                 && ((ShouldRemoveType(ms.ReturnType) && ms.MethodKind != MethodKind.LocalFunction)
@@ -1526,7 +1526,8 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
 
     private bool ShouldRemoveLiteral(LiteralExpressionSyntax literalExpression)
         => literalExpression.Token.IsKind(SyntaxKind.DefaultKeyword)
-           && semanticModel.GetTypeInfo(literalExpression).Type is INamedTypeSymbol { Name: "ValueTask", IsGenericType: false };
+           && semanticModel.GetTypeInfo(literalExpression).Type is INamedTypeSymbol { Name: "ValueTask", IsGenericType: false } t
+           && t.ToString() == ValueTaskType;
 
     /// <summary>
     /// Keeps track of nested directives.

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1550,7 +1550,8 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
         MemberAccessExpressionSyntax mae => ShouldRemoveArgument(mae.Name),
         PostfixUnaryExpressionSyntax pue => ShouldRemoveArgument(pue.Operand),
         PrefixUnaryExpressionSyntax pue => ShouldRemoveArgument(pue.Operand),
-        ObjectCreationExpressionSyntax oe => ShouldRemoveArgument(oe.Type),
+        ObjectCreationExpressionSyntax oe => ShouldRemoveArgument(oe.Type) || ShouldRemoveObjectCreation(oe),
+        ImplicitObjectCreationExpressionSyntax oe => ShouldRemoveObjectCreation(oe),
         ConditionalAccessExpressionSyntax cae => ShouldRemoveArgument(cae.Expression),
         AwaitExpressionSyntax ae => ShouldRemoveArgument(ae.Expression),
         AssignmentExpressionSyntax ae => ShouldRemoveArgument(ae.Right),
@@ -1563,6 +1564,10 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
         => literalExpression.Token.IsKind(SyntaxKind.DefaultKeyword)
            && semanticModel.GetTypeInfo(literalExpression).Type is INamedTypeSymbol { Name: "ValueTask", IsGenericType: false } t
            && t.ToString() == ValueTaskType;
+
+    private bool ShouldRemoveObjectCreation(BaseObjectCreationExpressionSyntax oe)
+        => GetSymbol(oe) is IMethodSymbol { ReceiverType: INamedTypeSymbol { Name: "ValueTask", IsGenericType: false } type }
+           && type.ToString() is ValueTaskType;
 
     /// <summary>
     /// Keeps track of nested directives.

--- a/tests/Generator.Tests/Snapshots/UnitTests.DropUnawaitedCompletedValueTask#DoSomethingAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.DropUnawaitedCompletedValueTask#DoSomethingAsync.g.verified.cs
@@ -1,0 +1,2 @@
+﻿//HintName: Test.Class.DoSomethingAsync.g.cs
+public static void DoSomething() { }

--- a/tests/Generator.Tests/Snapshots/UnitTests.KeepDefaultValueTaskWithResult#ReturnDefault.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.KeepDefaultValueTaskWithResult#ReturnDefault.g.verified.cs
@@ -1,0 +1,2 @@
+﻿//HintName: Test.Class.ReturnDefault.g.cs
+public static int ReturnDefault() => default;

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskInstance#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskInstance#ReturnAsync.g.verified.cs
@@ -1,0 +1,2 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+public static int Return() { return 1; }

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -110,9 +110,11 @@ public static Task DoSomethingAsync() {statement}
 
     [Theory]
     [InlineData("{ return default; }")]
+#if NETCOREAPP1_0_OR_GREATER
     [InlineData("{ return ValueTask.CompletedTask; }")]
     [InlineData("{ return ValueTask.CompletedTask; Console.WriteLine(\"123\"); }")]
     [InlineData("=> ValueTask.CompletedTask;")]
+#endif
     public Task DropUnawaitedCompletedValueTask(string statement) => $"""
 [Zomp.SyncMethodGenerator.CreateSyncVersion]
 public static ValueTask DoSomethingAsync() {statement}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -108,6 +108,16 @@ public async Task ExecAsync(CancellationToken ct)
 public static Task DoSomethingAsync() {statement}
 """.Verify(disableUnique: true);
 
+    [Theory]
+    [InlineData("{ return default; }")]
+    [InlineData("{ return ValueTask.CompletedTask; }")]
+    [InlineData("{ return ValueTask.CompletedTask; Console.WriteLine(\"123\"); }")]
+    [InlineData("=> ValueTask.CompletedTask;")]
+    public Task DropUnawaitedCompletedValueTask(string statement) => $"""
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public static ValueTask DoSomethingAsync() {statement}
+""".Verify(disableUnique: true);
+
     [Fact]
     public Task MultipleClasses() => """
 namespace NsOne

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -124,6 +124,15 @@ public static ValueTask DoSomethingAsync() {statement}
 public static ValueTask<int> ReturnDefault() => default;
 """.Verify();
 
+    [Theory]
+    [InlineData("{ return new(1); }")]
+    [InlineData("{ return new ValueTask<int>(1); }")]
+    [InlineData("{ return Task.FromResult(1); }")]
+    public Task ReturnValueTaskInstance(string statement) => $"""
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public static ValueTask<int> ReturnAsync() {statement}
+""".Verify(disableUnique: true);
+
     [Fact]
     public Task MultipleClasses() => """
 namespace NsOne

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -119,6 +119,12 @@ public static ValueTask DoSomethingAsync() {statement}
 """.Verify(disableUnique: true);
 
     [Fact]
+    public Task KeepDefaultValueTaskWithResult() => $"""
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public static ValueTask<int> ReturnDefault() => default;
+""".Verify();
+
+    [Fact]
     public Task MultipleClasses() => """
 namespace NsOne
 {

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -131,7 +131,7 @@ public static ValueTask<int> ReturnDefault() => default;
     [Theory]
     [InlineData("{ return new(1); }")]
     [InlineData("{ return new ValueTask<int>(1); }")]
-    [InlineData("{ return Task.FromResult(1); }")]
+    [InlineData("{ return ValueTask.FromResult(1); }")]
     public Task ReturnValueTaskInstance(string statement) => $"""
 [Zomp.SyncMethodGenerator.CreateSyncVersion]
 public static ValueTask<int> ReturnAsync() {statement}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -131,7 +131,9 @@ public static ValueTask<int> ReturnDefault() => default;
     [Theory]
     [InlineData("{ return new(1); }")]
     [InlineData("{ return new ValueTask<int>(1); }")]
+#if NETCOREAPP1_0_OR_GREATER
     [InlineData("{ return ValueTask.FromResult(1); }")]
+#endif
     public Task ReturnValueTaskInstance(string statement) => $"""
 [Zomp.SyncMethodGenerator.CreateSyncVersion]
 public static ValueTask<int> ReturnAsync() {statement}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -110,6 +110,8 @@ public static Task DoSomethingAsync() {statement}
 
     [Theory]
     [InlineData("{ return default; }")]
+    [InlineData("{ return new(); }")]
+    [InlineData("{ return new ValueTask(); }")]
 #if NETCOREAPP1_0_OR_GREATER
     [InlineData("{ return ValueTask.CompletedTask; }")]
     [InlineData("{ return ValueTask.CompletedTask; Console.WriteLine(\"123\"); }")]


### PR DESCRIPTION
This PR fixes dropping `ValueTask.CompletedTask`, `default` (when the return type is `ValueTask`) and `new ValueTask<T>(...)`.

## ValueTask
### Before
#### ValueTask.CompletedTask
```cs
public static ValueTask DoSomethingAsync() { return ValueTask.CompletedTask; }
public static ValueTask DoSomethingAsync() { return ValueTask.CompletedTask; Console.WriteLine(\"123\"); }
public static ValueTask DoSomethingAsync() => ValueTask.CompletedTask;

// -->

public static void DoSomething() { return global::System.Threading.Tasks.ValueTask.CompletedTask; }
```

#### Default
```cs
public static ValueTask DoSomethingAsync() { return default; }

// -->

public static void DoSomething() { return default; }
```

#### New
```cs
public static ValueTask DoSomethingAsync() { return new(); }

// -->

public static void DoSomething() { return new(); }
```

### After (PR)
```cs
public static ValueTask DoSomethingAsync() { return ValueTask.CompletedTask; }
public static ValueTask DoSomethingAsync() { return ValueTask.CompletedTask; Console.WriteLine(\"123\"); }
public static ValueTask DoSomethingAsync() => ValueTask.CompletedTask;
public static ValueTask DoSomethingAsync() { return default; }
public static ValueTask DoSomethingAsync() { return new(); }

// -->

public static void DoSomething() { }
```

## ValueTask\<T\>
### Before
```cs
public static ValueTask<int> ReturnAsync() => new(1);

// -->

public static int Return() { return new(1); }
```

### After (PR)
```cs
public static ValueTask<int> ReturnAsync() => new(1);

// -->

public static int Return() { return 1; }
```