### PR TITLE
Fix returning tasks

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -535,6 +535,15 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel) : CSharpS
                     .WithTrailingTrivia(node.GetTrailingTrivia());
             }
 
+            // Don't return if the return statement is the last statement in the method.
+            if (node.Parent.Parent is MethodDeclarationSyntax { Body.Statements: [.., var lastStatement] } &&
+                lastStatement == node)
+            {
+                return ExpressionStatement(result)
+                    .WithLeadingTrivia(node.GetLeadingTrivia())
+                    .WithTrailingTrivia(node.GetTrailingTrivia());
+            }
+
             // Create a block without the braces (eg. Return(); return;)
             return Block(List(new StatementSyntax[]
                 {

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq.Expressions;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+﻿using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Zomp.SyncMethodGenerator;
 

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnDefaultValueTask#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnDefaultValueTask#ReturnAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input)
+    {
+        return;
+    }
+    global::System.Console.WriteLine("123");
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnTask#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnTask#ReturnAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input)
+    {
+        Return(); return;
+    }
+    Return(); return;
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnTask#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnTask#ReturnAsync.g.verified.cs
@@ -5,5 +5,5 @@ private void Return(bool input)
     {
         Return(); return;
     }
-    Return(); return;
+    Return();
 }

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnTaskNoBody#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnTaskNoBody#ReturnAsync.g.verified.cs
@@ -2,5 +2,5 @@
 private void Return(bool input)
 {
     if (input) { Return(); return; }
-    Return(); return;
+    Return();
 }

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnTaskNoBody#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnTaskNoBody#ReturnAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input) { Return(); return; }
+    Return(); return;
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#GetMemoryOrSpanAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#GetMemoryOrSpanAsync.g.verified.cs
@@ -1,9 +1,0 @@
-﻿//HintName: Test.Class.GetMemoryOrSpanAsync.g.cs
-private void GetMemoryOrSpan(bool input)
-{
-    if (input)
-    {
-        Return(); return;
-    }
-    Return(); return;
-}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#GetMemoryOrSpanAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#GetMemoryOrSpanAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.GetMemoryOrSpanAsync.g.cs
+private void GetMemoryOrSpan(bool input)
+{
+    if (input)
+    {
+        Return(); return;
+    }
+    Return(); return;
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#ReturnAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input)
+    {
+        Return(); return;
+    }
+    Return(); return;
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTask#ReturnAsync.g.verified.cs
@@ -5,5 +5,5 @@ private void Return(bool input)
     {
         Return(); return;
     }
-    Return(); return;
+    Return();
 }

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditional#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditional#ReturnAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input) Return(); else Return();
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditionalFalse#ReturnFalseAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditionalFalse#ReturnFalseAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.ReturnFalseAsync.g.cs
+private void ReturnFalse(bool input)
+{
+    if (!input) Return();
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditionalTrue#ReturnTrueAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskConditionalTrue#ReturnTrueAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.ReturnTrueAsync.g.cs
+private void ReturnTrue(bool input)
+{
+    if (input) Return();
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskNoBody#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskNoBody#ReturnAsync.g.verified.cs
@@ -2,5 +2,5 @@
 private void Return(bool input)
 {
     if (input) { Return(); return; }
-    Return(); return;
+    Return();
 }

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskNoBody#ReturnAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReturnValueTaskNoBody#ReturnAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.ReturnAsync.g.cs
+private void Return(bool input)
+{
+    if (input) { Return(); return; }
+    Return(); return;
+}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -140,6 +140,64 @@ public static ValueTask<int> ReturnAsync() {statement}
 """.Verify(disableUnique: true);
 
     [Fact]
+    public Task ReturnValueTask() => """
+[CreateSyncVersion]
+private ValueTask GetMemoryOrSpanAsync(bool input)
+{
+    if (input)
+    {
+        return ReturnAsync();
+    }
+    return ReturnAsync();
+}
+
+private ValueTask ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
+    public Task ReturnValueTaskNoBody() => """
+[CreateSyncVersion]
+private ValueTask ReturnAsync(bool input)
+{
+    if (input) return ReturnAsync();
+    return ReturnAsync();
+}
+
+private ValueTask ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
+    public Task ReturnTask() => """
+[CreateSyncVersion]
+private Task ReturnAsync(bool input)
+{
+    if (input)
+    {
+        return ReturnAsync();
+    }
+    return ReturnAsync();
+}
+
+private Task ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
+    public Task ReturnTaskNoBody() => """
+[CreateSyncVersion]
+private Task ReturnAsync(bool input)
+{
+    if (input) return ReturnAsync();
+    return ReturnAsync();
+}
+
+private Task ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
     public Task MultipleClasses() => """
 namespace NsOne
 {

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -142,7 +142,7 @@ public static ValueTask<int> ReturnAsync() {statement}
     [Fact]
     public Task ReturnValueTask() => """
 [CreateSyncVersion]
-private ValueTask GetMemoryOrSpanAsync(bool input)
+private ValueTask ReturnAsync(bool input)
 {
     if (input)
     {

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -169,6 +169,42 @@ private void Return() { }
 """.Verify();
 
     [Fact]
+    public Task ReturnValueTaskConditional() => """
+[CreateSyncVersion]
+private ValueTask ReturnAsync(bool input)
+{
+    return input ? ReturnAsync() : ReturnAsync();
+}
+
+private ValueTask ReturnAsync() => ReturnAsync();
+private void Return() { }
+""".Verify();
+
+    [Fact]
+    public Task ReturnValueTaskConditionalTrue() => """
+[CreateSyncVersion]
+private ValueTask ReturnTrueAsync(bool input)
+{
+    return input ? ReturnAsync() : default;
+}
+
+private ValueTask ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
+    public Task ReturnValueTaskConditionalFalse() => """
+[CreateSyncVersion]
+private ValueTask ReturnFalseAsync(bool input)
+{
+    return input ? default : ReturnAsync();
+}
+
+private ValueTask ReturnAsync() => default;
+private void Return() { }
+""".Verify();
+
+    [Fact]
     public Task ReturnTask() => """
 [CreateSyncVersion]
 private Task ReturnAsync(bool input)

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -180,7 +180,7 @@ private Task ReturnAsync(bool input)
     return ReturnAsync();
 }
 
-private Task ReturnAsync() => default;
+private Task ReturnAsync() => Task.CompletedTask;
 private void Return() { }
 """.Verify();
 
@@ -193,7 +193,7 @@ private Task ReturnAsync(bool input)
     return ReturnAsync();
 }
 
-private Task ReturnAsync() => default;
+private Task ReturnAsync() => Task.CompletedTask;
 private void Return() { }
 """.Verify();
 

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -198,6 +198,20 @@ private void Return() { }
 """.Verify();
 
     [Fact]
+    public Task ReturnDefaultValueTask() => """
+[CreateSyncVersion]
+private ValueTask ReturnAsync(bool input)
+{
+    if (input)
+    {
+        return default;
+    }
+    Console.WriteLine("123");
+    return default;
+}
+""".Verify();
+
+    [Fact]
     public Task MultipleClasses() => """
 namespace NsOne
 {


### PR DESCRIPTION
Fix rewriting the return statement when the task is directly returned from an expression.

# With a body
```cs
[CreateSyncVersion]
private ValueTask ReturnAsync(bool input)
{
    if (input)
    {
        return ReturnAsync();
    }
    return ReturnAsync();
}

private ValueTask ReturnAsync() => default;
private void Return() { }
```

## Before
Invalid because the `Return`-method returns `void`.
```cs
private void Return(bool input)
{
    if (input)
    {
        return Return();
    }
    return Return();
}
```

## After
```cs
private void Return(bool input)
{
    if (input)
    {
        Return(); return;
    }
    Return();
}
```

# Without a body
```cs
[CreateSyncVersion]
private ValueTask ReturnAsync(bool input)
{
    if (input) return ReturnAsync();
    return ReturnAsync();
}

private ValueTask ReturnAsync() => default;
private void Return() { }
```

## Before
Invalid because the `Return`-method returns `void`.
```cs
private void Return(bool input)
{
    if (input) return Return();
    return Return();
}
```

## After
```cs
private void Return(bool input)
{
    if (input) { Return(); return; }
    Return();
}
```