### PR TITLE
Add support for the .NET 8 SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.11.0]" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="N.SourceGenerators.UnionTypes" Version="0.28.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
@@ -15,7 +15,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Experimental" Version="6.0.2" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XUnit" Version="30.1.0" />
+    <PackageVersion Include="Verify.Xunit" Version="30.3.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Downgrading Microsoft.CodeAnalysis.CSharp from version 4.13.0 to 4.11.0 enables using Zomp.SyncMethodGenerator with the .NET 8 SDK at the very small price of using `nameof(Nullable<int>.*)` instead of `nameof(Nullable<>.*)`

Currently, using Zomp.SyncMethodGenerator with the .NET 8 SDK fails with this error.
> error CS9057: The analyzer assembly 'Zomp.SyncMethodGenerator.dll' references version '4.13.0.0' of the compiler, which is newer than the currently running version '4.11.0.0'.