### PR TITLE
Add option to preserve IProgress<T> parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A list of changes applied to the new synchronized method:
 - \* [ValueTask](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask)s are handled exactly like [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task)s
 - Remove parameters
   - [CancellationToken](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken)
-  - [IProgress\<T>](https://learn.microsoft.com/en-us/dotnet/api/system.iprogress-1)
+  - [IProgress\<T>](https://learn.microsoft.com/en-us/dotnet/api/system.iprogress-1), unless the `PreserveProgress` property is set to `true`.
 - Invocation changes
   - Remove `ConfigureAwait` from [Tasks](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.configureawait) and [Asynchronous Enumerations](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskasyncenumerableextensions.configureawait)
   - Remove [WithCancellation](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskasyncenumerableextensions.withcancellation)
@@ -81,6 +81,18 @@ This source generator detects language version during the compilation. By defaul
 public async Task MethodAsync()
 {
     string f = null;
+}
+```
+
+#### PreserveProgress
+
+By default, this source generator removes `IProgress<T>` parameters from async methods. To preserve them, use the `PreserveProgress` option.
+
+```cs
+[Zomp.SyncMethodGenerator.CreateSyncVersion(PreserveProgress = true)]
+public async Task MethodAsync(IProgress<double> progress)
+{
+  progress.Report(0.0);
 }
 ```
 

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1593,33 +1593,6 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
             Token(SyntaxKind.CloseBraceToken)
             .PrependSpace());
 
-    private bool ShouldRemoveType(ITypeSymbol symbol)
-    {
-        if (symbol is IArrayTypeSymbol at)
-        {
-            return ShouldRemoveType(at.ElementType);
-        }
-
-        if (symbol is not INamedTypeSymbol namedSymbol)
-        {
-            return false;
-        }
-
-        foreach (var @interface in GetInterfaces(namedSymbol))
-        {
-            if (IsIProgress(@interface) || @interface is
-                {
-                    Name: IAsyncResult, IsGenericType: false,
-                    ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true }
-                })
-            {
-                return !preserveProgress;
-            }
-        }
-
-        return (IsIProgress(namedSymbol) && !preserveProgress) || IsCancellationToken(namedSymbol);
-    }
-
     private static ITypeSymbol GetReturnType(ISymbol symbol) => symbol switch
     {
         IFieldSymbol fs => fs.Type,
@@ -1631,35 +1604,6 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         IDiscardSymbol ds => ds.Type,
         IEventSymbol es => es.Type,
         _ => throw new NotSupportedException($"Can't process {symbol}"),
-    };
-
-    private bool ShouldRemoveArgument(ISymbol symbol, bool isNegated = false) => symbol switch
-    {
-        IPropertySymbol
-        {
-            Name: CompletedTask, Type: INamedTypeSymbol
-            {
-                Name: Task or ValueTask, IsGenericType: false,
-                ContainingNamespace: { Name: Tasks, ContainingNamespace: { Name: Threading, ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true } } }
-            }
-        }
-
-        => true,
-        IPropertySymbol
-        {
-            Name: IsCancellationRequested, ContainingType:
-            {
-                Name: CancellationToken, IsGenericType: false,
-                ContainingNamespace: { Name: Threading, ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true } }
-            }
-        }
-
-        => !isNegated,
-        IMethodSymbol ms =>
-            IsSpecialMethod(ms) == SpecialMethod.None
-                && ((ShouldRemoveType(ms.ReturnType) && ms.MethodKind != MethodKind.LocalFunction)
-                    || (ms.ReceiverType is { } receiver && ShouldRemoveType(receiver))),
-        _ => ShouldRemoveType(GetReturnType(symbol)),
     };
 
     private static MemberAccessExpressionSyntax AppendSpan(ExpressionSyntax @base)
@@ -1861,6 +1805,62 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
 
         return newTypeSyntax;
     }
+
+    private bool ShouldRemoveType(ITypeSymbol symbol)
+    {
+        if (symbol is IArrayTypeSymbol at)
+        {
+            return ShouldRemoveType(at.ElementType);
+        }
+
+        if (symbol is not INamedTypeSymbol namedSymbol)
+        {
+            return false;
+        }
+
+        foreach (var @interface in GetInterfaces(namedSymbol))
+        {
+            if (IsIProgress(@interface) || @interface is
+                {
+                    Name: IAsyncResult, IsGenericType: false,
+                    ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true }
+                })
+            {
+                return !preserveProgress;
+            }
+        }
+
+        return (IsIProgress(namedSymbol) && !preserveProgress) || IsCancellationToken(namedSymbol);
+    }
+
+    private bool ShouldRemoveArgument(ISymbol symbol, bool isNegated = false) => symbol switch
+    {
+        IPropertySymbol
+        {
+            Name: CompletedTask, Type: INamedTypeSymbol
+            {
+                Name: Task or ValueTask, IsGenericType: false,
+                ContainingNamespace: { Name: Tasks, ContainingNamespace: { Name: Threading, ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true } } }
+            }
+        }
+
+        => true,
+        IPropertySymbol
+        {
+            Name: IsCancellationRequested, ContainingType:
+            {
+                Name: CancellationToken, IsGenericType: false,
+                ContainingNamespace: { Name: Threading, ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true } }
+            }
+        }
+
+        => !isNegated,
+        IMethodSymbol ms =>
+            IsSpecialMethod(ms) == SpecialMethod.None
+                && ((ShouldRemoveType(ms.ReturnType) && ms.MethodKind != MethodKind.LocalFunction)
+                    || (ms.ReceiverType is { } receiver && ShouldRemoveType(receiver))),
+        _ => ShouldRemoveType(GetReturnType(symbol)),
+    };
 
     private bool PreProcess(
         SyntaxList<StatementSyntax> statements,

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -10,7 +10,8 @@ namespace Zomp.SyncMethodGenerator;
 /// </remarks>
 /// <param name="semanticModel">The semantic model.</param>
 /// <param name="disableNullable">Instructs the source generator that nullable context should be disabled.</param>
-internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disableNullable) : CSharpSyntaxRewriter
+/// <param name="preserveProgress">Instructs the source generator to preserve <see cref="IProgress"/> parameters.</param>
+internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disableNullable, bool preserveProgress) : CSharpSyntaxRewriter
 {
     public const string SyncOnly = "SYNC_ONLY";
 
@@ -68,6 +69,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
 
     private readonly SemanticModel semanticModel = semanticModel;
     private readonly bool disableNullable = disableNullable;
+    private readonly bool preserveProgress = preserveProgress;
     private readonly HashSet<IParameterSymbol> removedParameters = [];
     private readonly Dictionary<string, string> renamedLocalFunctions = [];
     private readonly ImmutableArray<ReportedDiagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<ReportedDiagnostic>();
@@ -1591,7 +1593,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
             Token(SyntaxKind.CloseBraceToken)
             .PrependSpace());
 
-    private static bool ShouldRemoveType(ITypeSymbol symbol)
+    private bool ShouldRemoveType(ITypeSymbol symbol)
     {
         if (symbol is IArrayTypeSymbol at)
         {
@@ -1611,11 +1613,11 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
                     ContainingNamespace: { Name: System, ContainingNamespace.IsGlobalNamespace: true }
                 })
             {
-                return true;
+                return !preserveProgress;
             }
         }
 
-        return IsIProgress(namedSymbol) || IsCancellationToken(namedSymbol);
+        return (IsIProgress(namedSymbol) && !preserveProgress) || IsCancellationToken(namedSymbol);
     }
 
     private static ITypeSymbol GetReturnType(ISymbol symbol) => symbol switch
@@ -1631,7 +1633,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         _ => throw new NotSupportedException($"Can't process {symbol}"),
     };
 
-    private static bool ShouldRemoveArgument(ISymbol symbol, bool isNegated = false) => symbol switch
+    private bool ShouldRemoveArgument(ISymbol symbol, bool isNegated = false) => symbol switch
     {
         IPropertySymbol
         {

--- a/src/Zomp.SyncMethodGenerator/SourceGenerationHelper.cs
+++ b/src/Zomp.SyncMethodGenerator/SourceGenerationHelper.cs
@@ -20,6 +20,11 @@ namespace Zomp.SyncMethodGenerator
         /// Gets or sets a value indicating whether "#nullable enable" directive will be omitted from generated code. False by default.
         /// </summary>
         public bool {{SyncMethodSourceGenerator.OmitNullableDirective}} { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="System.IProgress{T}"/> parameters will be preserved in the generated code. False by default.
+        /// </summary>
+        public bool {{SyncMethodSourceGenerator.PreserveProgress}} { get; set; }
     }
     #endif
 }

--- a/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
+++ b/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
@@ -13,6 +13,7 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
     internal const string QualifiedCreateSyncVersionAttribute = $"{ThisAssembly.RootNamespace}.{CreateSyncVersionAttribute}";
 
     internal const string OmitNullableDirective = "OmitNullableDirective";
+    internal const string PreserveProgress = "PreserveProgress";
 
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -137,9 +138,6 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             break;
         }
 
-        var explicitDisableNullable = syncMethodGeneratorAttributeData.NamedArguments.FirstOrDefault(c => c.Key == OmitNullableDirective) is { Value.Value: true };
-        disableNullable |= explicitDisableNullable;
-
         var classes = ImmutableArray.CreateBuilder<MethodParentDeclaration>();
         SyntaxNode? node = methodDeclarationSyntax;
         while (node.Parent is not null)
@@ -167,7 +165,12 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             return null;
         }
 
-        var rewriter = new AsyncToSyncRewriter(context.SemanticModel, disableNullable);
+        var explicitDisableNullable = syncMethodGeneratorAttributeData.NamedArguments.FirstOrDefault(c => c.Key == OmitNullableDirective) is { Value.Value: true };
+        disableNullable |= explicitDisableNullable;
+
+        var preserveProgress = syncMethodGeneratorAttributeData.NamedArguments.FirstOrDefault(c => c.Key == PreserveProgress) is { Value.Value: true };
+
+        var rewriter = new AsyncToSyncRewriter(context.SemanticModel, disableNullable,  preserveProgress);
         var sn = rewriter.Visit(methodDeclarationSyntax);
         var content = sn.ToFullString();
 

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(someBool ? progress : null);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(Progress-float-)classWithProgress#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(Progress-float-)classWithProgress#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress((global::System.Progress<float>)global::Test.Class.classWithProgress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(Progress-float-)progress#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(Progress-float-)progress#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress((global::System.Progress<float>)progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(progress)#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=(progress)#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress((progress));
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=ProgressFunc(progress)#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=ProgressFunc(progress)#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(global::Test.Class.ProgressFunc(progress));
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=SomeMethod(progress)#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=SomeMethod(progress)#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(SomeMethod(progress));
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=array[0]#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=array[0]#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(global::Test.Class.array[0]);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=classWithProgress.Property#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=classWithProgress.Property#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(classWithProgress.Property);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=customProgress + customProgress#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=customProgress + customProgress#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(global::Test.Class.customProgress + global::Test.Class.customProgress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=customProgress++#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=customProgress++#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(global::Test.Class.customProgress++);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=new CustomProgress()#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=new CustomProgress()#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(new global::Test.Class.CustomProgress());
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=progress as IProgress-float-#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=progress as IProgress-float-#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(progress as global::System.IProgress<float>);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=progress#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=progress#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=someBool - null - progress#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=someBool - null - progress#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(someBool ? null : progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=someBool - progress - null#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressExpressionArgument_callArgument=someBool - progress - null#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,6 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    var progress = new global::System.Progress<float>();
+    WithIProgress(someBool ? progress : null);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (false) { } else if (true) progress++; else { }#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (false) { } else if (true) progress++; else { }#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    if (false) { } else if (true) progress++; else { }
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (false) { } else if (true) progress++;#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (false) { } else if (true) progress++;#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    if (false) { } else if (true) progress++;
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) progress++;#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) progress++;#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    if (true) progress++;
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) { progress++; }#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) { progress++; }#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    if (true) { progress++; }
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) { } else progress++;#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=if (true) { } else progress++;#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    if (true) { } else progress++;
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=progress++;#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=progress++;#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,9 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    progress++;
+
+    WithIProgress(progress);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=switch (k)--{--    case 1---        progress++;--        break;--    default---        progress++;--        progress++;--        break;--}#CallWithIProgressAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.PreserveIProgressStatement_statement=switch (k)--{--    case 1---        progress++;--        break;--    default---        progress++;--        progress++;--        break;--}#CallWithIProgressAsync.g.verified.cs
@@ -1,0 +1,18 @@
+﻿//HintName: Test.Class.CallWithIProgressAsync.g.cs
+public static void CallWithIProgress()
+{
+    global::Test.Class.CustomProgress progress = new();
+
+    switch (global::Test.Class.k)
+{
+    case 1:
+        progress++;
+        break;
+    default:
+        progress++;
+        progress++;
+        break;
+}
+
+    WithIProgress(progress);
+}


### PR DESCRIPTION
Removing `IProgress<T>` parameters by default makes sense but it could also cause the generated sync code to not compile anymore.

For example, I have `ProgressStream` class that wraps a `Stream` and provides progress while reading the stream (for both sync and async). It takes an `IProgress<long>` in its constructor so completely removing `IProgress<T>` fails the compilation.

```csharp
public class ProgressStream : Stream
{
    private readonly Stream _stream;
    private long _bytesRead;

    public ProgressStream(Stream stream, IProgress<long> progress)
    {
        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
        Progress = progress ?? throw new ArgumentNullException(nameof(progress));
    }

    private long BytesRead
    {
        get => _bytesRead;
        set
        {
            _bytesRead = value;
            Progress.Report(_bytesRead);
        }
    }

    public override int Read(byte[] buffer, int offset, int count)
    {
        var bytesRead = _stream.Read(buffer, offset, count);
        BytesRead += bytesRead;
        return bytesRead;
    }

    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
    {
        var bytesRead = await _stream.ReadAsync(buffer, offset, count, cancellationToken);
        BytesRead += bytesRead;
        return bytesRead;
    }

    // ... full implementation skipped for brevity
}
```

The new `PreserveProgress` option allows to preserve `IProgress<T>` parameters if needed.