### PR TITLE
chore: optimize debug launch configuration

### DIFF
--- a/src/Zomp.SyncMethodGenerator/Properties/launchSettings.json
+++ b/src/Zomp.SyncMethodGenerator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Zomp.SyncMethodGenerator": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\..\\tests\\GenerationSandbox.Tests\\GenerationSandbox.Tests.csproj"
+    }
+  }
+}

--- a/src/Zomp.SyncMethodGenerator/Zomp.SyncMethodGenerator.csproj
+++ b/src/Zomp.SyncMethodGenerator/Zomp.SyncMethodGenerator.csproj
@@ -17,6 +17,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <PackageTags>async sync csharp source generator</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <!-- This ensures the library will be packaged as a source generator when we use `dotnet pack` -->


### PR DESCRIPTION
As far as I know, debugging `SourceGenerator`  can be quite troublesome. I know a configuration method that allows you to start debugging with F5 directly. Follow these steps:

> I'm sorry that my screenshot is in Chinese, but you should be able to find the options easily.

1. Install the `.NET Compiler Platform SDK` in Visual Studio.
![image](https://github.com/user-attachments/assets/88304088-a72f-4140-9632-de9840935aec)

2. Configure the debug properties.
![image](https://github.com/user-attachments/assets/1189514e-aa86-42a6-b4ab-453b24b8d694)
![image](https://github.com/user-attachments/assets/7b8e45ad-9ad0-4203-9a23-9b04b225b0ec)

After that, you'll be able to start debugging just like with a regular project.

![image](https://github.com/user-attachments/assets/7611fa55-11cf-4e3d-b478-bdcb5f1de89d)
