### PR TITLE
feat: adjust the logic for determining disableNullable value

### DIFF
--- a/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
+++ b/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
@@ -29,8 +29,12 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             $"{CreateSyncVersionAttribute}.g.cs", SourceText.From(SourceGenerationHelper.CreateSyncVersionAttributeSource, Encoding.UTF8)));
 
         var disableNullable =
-            context.CompilationProvider.Select((c, _)
-                => c is CSharpCompilation { LanguageVersion: < LanguageVersion.CSharp8 });
+            context.CompilationProvider.Select((c, _) =>
+            {
+                var isNullableDisabledInProject = c.Options.NullableContextOptions == NullableContextOptions.Disable;
+                var isLanguageVersionBelowCSharp8 = c is CSharpCompilation { LanguageVersion: < LanguageVersion.CSharp8 };
+                return isNullableDisabledInProject || isLanguageVersionBelowCSharp8;
+            });
 
         var methodDeclarations = context.SyntaxProvider
             .ForAttributeWithMetadataName(


### PR DESCRIPTION
Previously, `disableNullable` could not determine its value based on the configuration in `.csproj`. This PR adjusts the logic to read the `.csproj` configuration, significantly reducing unnecessary warnings during compilation.

Before:
![B~S}_QG23C_B$0I`20_(9WG](https://github.com/user-attachments/assets/a817518d-d9c7-4ead-8dd9-021499667a85)

After:
![VIR5G8OV1M}3WFBQZ~)BEP4](https://github.com/user-attachments/assets/3c90087c-03ab-428c-9d3d-123d08e9073e)
