### PR TITLE
Keep invocation if sync method exists

### DIFF
--- a/tests/Generator.Tests/Snapshots/TypeTests.SemaphoreSlimWaitAndRelease#g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/TypeTests.SemaphoreSlimWaitAndRelease#g.verified.cs
@@ -1,0 +1,12 @@
+﻿//HintName: Test.Class.MethodAsync.g.cs
+var semaphore = new global::System.Threading.SemaphoreSlim(1, 1);
+
+semaphore.Wait();
+
+try
+{ 
+}
+finally
+{
+    semaphore.Release();
+}

--- a/tests/Generator.Tests/TypeTests.cs
+++ b/tests/Generator.Tests/TypeTests.cs
@@ -270,4 +270,20 @@ internal partial class Class<T>
     public Task CreateNullableType()
         => "new Dictionary<int, (int I, Stream? S)?>().TryGetValue(0, out (int I, Stream? S)? a);"
         .Verify(sourceType: SourceType.MethodBody);
+
+    [Fact]
+    public Task SemaphoreSlimWaitAndRelease()
+        => """
+var semaphore = new SemaphoreSlim(1, 1);
+
+await semaphore.WaitAsync();
+
+try
+{ 
+}
+finally
+{
+    semaphore.Release();
+}
+""".Verify(sourceType: SourceType.MethodBody);
 }


### PR DESCRIPTION
Invocations that return a task are being removed from the sync method. For example:

```cs
var semaphore = new global::System.Threading.SemaphoreSlim(1, 1);

await semaphore.WaitAsync();

try
{ 
}
finally
{
    semaphore.Release();
}
```

Would translate to:

```cs
var semaphore = new global::System.Threading.SemaphoreSlim(1, 1);

try
{ 
}
finally
{
    semaphore.Release();
}
```

Because of this, the lock will never acquired and `Release` throws an exception.
This PR checks if a non-async method exists and keeps the invocation, which is the case for SemaphoreSlim.

Now the result is:

```cs
var semaphore = new global::System.Threading.SemaphoreSlim(1, 1);

semaphore.Wait();

try
{ 
}
finally
{
    semaphore.Release();
}
```