### PR TITLE
Fix rewriter when the sync method is in the same extensions class

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1844,7 +1844,18 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         var newName = reducedFrom.Name;
         newName = changeMemoryToSpan ? GetNewName(reducedFrom) : RemoveAsync(newName);
 
-        var fullyQualifiedName = $"{MakeType(reducedFrom.ContainingType)}.{newName}";
+        var newNameExistsInContainingType = semanticModel.Compilation.References
+            .Select(semanticModel.Compilation.GetAssemblyOrModuleSymbol)
+            .Append(semanticModel.Compilation.Assembly)
+            .OfType<IAssemblySymbol>()
+            .Select(assemblySymbol => assemblySymbol.GetTypeByMetadataName(reducedFrom.ContainingType.ToString()))
+            .OfType<INamedTypeSymbol>()
+            .SelectMany(symbol => symbol.GetMembers(newName))
+            .Any();
+
+        var fullyQualifiedName = newNameExistsInContainingType
+            ? $"{reducedFrom.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{newName}"
+            : $"{MakeType(reducedFrom.ContainingType)}.{newName}";
 
         var es = (ies.Expression switch
         {

--- a/tests/GenerationSandbox.Tests/EntityFrameworkQueryableExtensions.cs
+++ b/tests/GenerationSandbox.Tests/EntityFrameworkQueryableExtensions.cs
@@ -1,8 +1,7 @@
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Zomp.SyncMethodGenerator.IntegrationTests;
+namespace GenerationSandbox.Tests;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -14,12 +13,18 @@ public partial class EntityFrameworkQueryableExtensions
     /// <summary>
     /// Test method.
     /// </summary>
-    /// <param name="source">The source.</param>
+    /// <param name="dbContext">The db context.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The result.</returns>
     [Zomp.SyncMethodGenerator.CreateSyncVersion]
-    public async Task<bool> QueryableExtensionAsync(IQueryable<object> source, CancellationToken cancellationToken)
+    public async Task<int> QueryableExtensionAsync(DbContext dbContext, CancellationToken cancellationToken)
     {
-        return await source.AnyAsync(cancellationToken);
+        var dbSet = dbContext.Set<object>();
+        if (await dbSet.AnyAsync(cancellationToken))
+        {
+            return await dbSet.ExecuteDeleteAsync(cancellationToken);
+        }
+
+        return 0;
     }
 }

--- a/tests/Generator.Tests/ExtensionMethodTests.cs
+++ b/tests/Generator.Tests/ExtensionMethodTests.cs
@@ -122,7 +122,6 @@ static partial class Class
 
     [Fact]
     public Task EntityFrameworkQueryableExtensions() => """
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -133,9 +132,15 @@ namespace Zomp.SyncMethodGenerator.IntegrationTests
     public partial class EntityFrameworkQueryableExtensions
     {
         [Zomp.SyncMethodGenerator.CreateSyncVersion]
-        public async Task<bool> QueryableExtensionAsync(IQueryable<object> source, CancellationToken cancellationToken)
+        public async Task<int> QueryableExtensionAsync(DbContext dbContext, CancellationToken cancellationToken)
         {
-            return await source.AnyAsync(cancellationToken);
+            var dbSet = dbContext.Set<object>();
+            if (await dbSet.AnyAsync(cancellationToken))
+            {
+                return await dbSet.ExecuteDeleteAsync(cancellationToken);
+            }
+            
+            return 0;
         }
     }
 }

--- a/tests/Generator.Tests/Snapshots/ExtensionMethodTests.EntityFrameworkQueryableExtensions#Zomp.SyncMethodGenerator.IntegrationTests.EntityFrameworkQueryableExtensions.QueryableExtensionAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/ExtensionMethodTests.EntityFrameworkQueryableExtensions#Zomp.SyncMethodGenerator.IntegrationTests.EntityFrameworkQueryableExtensions.QueryableExtensionAsync.g.verified.cs
@@ -5,9 +5,15 @@ namespace Zomp.SyncMethodGenerator.IntegrationTests
 {
     public partial class EntityFrameworkQueryableExtensions
     {
-        public bool QueryableExtension(global::System.Linq.IQueryable<object> source)
+        public int QueryableExtension(global::Microsoft.EntityFrameworkCore.DbContext dbContext)
         {
-            return global::System.Linq.Queryable.Any(source);
+            var dbSet = dbContext.Set<object>();
+            if (global::System.Linq.Queryable.Any(dbSet))
+            {
+                return global::Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ExecuteDelete(dbSet);
+            }
+            
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Pull request #108 made sure that EF Core async extensions (such as `AnyAsync` are properly translated to the `System.Linq.Queryable.Any` extension method).

Unfortunately, this introduced a regression. When async and sync methods are in the same extension class (such as [ExecuteDeleteAsync](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.relationalqueryableextensions.executedeleteasync) and [ExecuteDelete](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.relationalqueryableextensions.executedelete)) the generated sync method would be wrong. I.e., generated in `System.Linq.Queryable` instead of `Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions`.

This pull request tries to address this issue. Unfortunately, I'm again facing discrepancies between the `GenerationSandbox.Tests` and `Generator.Tests` projects. This is why this pull request is opened a draft.

When used in the `GenerationSandbox.Tests` project, the generated code is correct.

```csharp
// <auto-generated/>
#nullable enable
namespace GenerationSandbox.Tests
{
    public partial class EntityFrameworkQueryableExtensions
    {
        /// <summary>
        /// Test method.
        /// </summary>
        /// <param name="dbContext">The db context.</param>
        /// <returns>The result.</returns>
        public int QueryableExtension(global::Microsoft.EntityFrameworkCore.DbContext dbContext)
        {
            var dbSet = dbContext.Set<object>();
            if (global::System.Linq.Queryable.Any(dbSet))
            {
                return global::Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ExecuteDelete(dbSet);
            }

            return 0;
        }
    }
}
```

When generated in the `Generator.Tests` project, the generated code is incorrect. Note how the 
`Any` and `ExecuteDelete` methods are **not** generated with their fully qualified names.

```csharp
//HintName: Zomp.SyncMethodGenerator.IntegrationTests.EntityFrameworkQueryableExtensions.QueryableExtensionAsync.g.cs
// <auto-generated/>
#nullable enable
namespace Zomp.SyncMethodGenerator.IntegrationTests
{
    public partial class EntityFrameworkQueryableExtensions
    {
        public int QueryableExtension(global::Microsoft.EntityFrameworkCore.DbContext dbContext)
        {
            var dbSet = dbContext.Set<object>();
            if (dbSet.Any())
            {
                return dbSet.ExecuteDelete();
            }
            
            return 0;
        }
    }
}
```

I don't understand why the generated code is different. I have identified that [var symbol = GetSymbol(node)](https://github.com/zompinc/sync-method-generator/blob/56661c31a4e1e0ebf9c0e8ccef863d073e6fcb28/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs#L535) returns null for `InvocationExpressionSyntax InvocationExpression dbSet.AnyAsync(cancellationToken)` in `Generator.Tests` and not null in `GenerationSandbox.Tests` but I don't understand why.