### PR TITLE
Simplify the metadata references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Fody" Version="6.6.4" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />

--- a/tests/Generator.Tests/Generator.Tests.csproj
+++ b/tests/Generator.Tests/Generator.Tests.csproj
@@ -17,6 +17,7 @@
     <None Include="GenericMathTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)' != 'net472'" />
     <PackageReference Include="PolySharp">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Generator.Tests/TestHelper.cs
+++ b/tests/Generator.Tests/TestHelper.cs
@@ -1,8 +1,5 @@
-﻿using System.ComponentModel;
-using System.Data.Common;
-using System.Diagnostics;
+using Basic.Reference.Assemblies;
 using System.Text.RegularExpressions;
-using System.Xml;
 using Zomp.SyncMethodGenerator;
 using static Generator.Tests.ModuleInitializer;
 
@@ -88,46 +85,6 @@ namespace Test;
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
         var globalUsings = CSharpSyntaxTree.ParseText(GlobalUsingsSource, parseOptions);
 
-        // SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
-        var linqAssembly = typeof(Enumerable).Assembly.Location;
-        var locations = new List<string>
-        {
-            typeof(IAsyncEnumerable<>).Assembly.Location,
-            typeof(DataReceivedEventHandler).Assembly.Location,
-            typeof(DbDataReader).Assembly.Location,
-            typeof(ValueTask<>).Assembly.Location,
-            typeof(System.Drawing.Point).Assembly.Location,
-            typeof(object).Assembly.Location,
-            typeof(Console).Assembly.Location,
-            typeof(Memory<>).Assembly.Location,
-            typeof(System.Buffers.MemoryPool<>).Assembly.Location,
-            typeof(Queue<>).Assembly.Location,
-            typeof(LinkedListNode<>).Assembly.Location,
-            typeof(XmlReader).Assembly.Location,
-            typeof(IQueryable).Assembly.Location,
-            typeof(System.Net.HttpStatusCode).Assembly.Location,
-            typeof(IListSource).Assembly.Location,
-            typeof(Regex).Assembly.Location,
-            typeof(Queryable).Assembly.Location,
-#if NET8_0_OR_GREATER
-            typeof(AsyncEnumerable).Assembly.Location,
-            typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions).Assembly.Location,
-#endif
-            linqAssembly,
-        };
-
-        var directory = Path.GetDirectoryName(linqAssembly);
-        var runtimeLocation = directory is null ? null : Path.Combine(directory, "System.Runtime.dll");
-        if (runtimeLocation is not null && File.Exists(runtimeLocation))
-        {
-            locations.Add(runtimeLocation);
-        }
-
-        var distinct = locations.Distinct().ToArray();
-
-        var references = distinct
-            .Select(l => MetadataReference.CreateFromFile(l));
-
         List<SyntaxTree> syntaxTrees = [syntaxTree];
 
         if (languageVersion >= LanguageVersion.CSharp10)
@@ -135,11 +92,19 @@ namespace Test;
             syntaxTrees.Add(globalUsings);
         }
 
+#if NET8_0_OR_GREATER
+        var assemblies = new[]
+        {
+            typeof(Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions).Assembly,
+        };
+#else
+        IEnumerable<System.Reflection.Assembly> assemblies = [];
+#endif
         var compilation = CSharpCompilation.Create(
             assemblyName: "Tests",
             options: new(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: languageVersion >= LanguageVersion.CSharp8 ? NullableContextOptions.Enable : NullableContextOptions.Disable),
             syntaxTrees: syntaxTrees,
-            references: references);
+            references: Net100.References.All.Concat(assemblies.Select(a => MetadataReference.CreateFromFile(a.Location))));
 
         var generator = new SyncMethodSourceGenerator();
 


### PR DESCRIPTION
In the past (#107 and #110) I experienced issues in the unit test project because if missing references in the C# compilation. It was really hard to pinpoint which references were missing.

Using the Basic.Reference.Assemblies.Net100 NuGet package and adding all the metadata references ensures that all references are available and that the compilation will work as expected.