### PR TITLE
Fixes asynchronous LINQ methods not being converted to their synchronous counterparts

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1875,16 +1875,17 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         var newName = reducedFrom.Name;
         newName = changeMemoryToSpan ? GetNewName(reducedFrom) : RemoveAsync(newName);
 
-        var newNameExistsInContainingType = semanticModel.Compilation.References
+        var membersWithNewNameInContainingType = semanticModel.Compilation.References
             .Select(semanticModel.Compilation.GetAssemblyOrModuleSymbol)
             .Append(semanticModel.Compilation.Assembly)
             .OfType<IAssemblySymbol>()
             .Select(assemblySymbol => assemblySymbol.GetTypeByMetadataName(reducedFrom.ContainingType.ToString()))
             .OfType<INamedTypeSymbol>()
-            .SelectMany(symbol => symbol.GetMembers(newName))
-            .Any();
+            .SelectMany(symbol => symbol.GetMembers(newName));
 
-        var fullyQualifiedName = newNameExistsInContainingType
+        // When the method is an AsyncEnumerable extension it must be converted to the corresponding Enumerable extension
+        // regardless of the containing type featuring members with compatible names
+        var fullyQualifiedName = !reducedFrom.ContainingType.Name.Equals("AsyncEnumerable", StringComparison.Ordinal) && membersWithNewNameInContainingType.Any()
             ? $"{reducedFrom.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{newName}"
             : $"{MakeType(reducedFrom.ContainingType)}.{newName}";
 

--- a/tests/Generator.Tests/Snapshots/SystemAsyncExtensionsTests.LinqConversion#g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/SystemAsyncExtensionsTests.LinqConversion#g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.MethodAsync.g.cs
+public void Method(global::System.Collections.Generic.IEnumerable<int> foo)
+{
+    var elements = global::System.Linq.Enumerable.ToList(global::System.Linq.Enumerable.Where(global::System.Linq.Enumerable.Select(foo, i => i + 5), i => i > 0));
+}

--- a/tests/Generator.Tests/SystemAsyncExtensionsTests.cs
+++ b/tests/Generator.Tests/SystemAsyncExtensionsTests.cs
@@ -202,4 +202,15 @@ internal static partial class Extensions
     }
 }
 """.Verify(sourceType: SourceType.Full);
+
+#if NET
+    [Fact]
+    public Task LinqConversion() => """
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public async Task MethodAsync(IAsyncEnumerable<int> foo)
+{
+    var elements = await foo.Select(i => i + 5).Where(i => i > 0).ToListAsync();
+}
+""".Verify();
+#endif
 }


### PR DESCRIPTION
This PR addresses a small regression causing `IAsyncEnumerable` LINQ methods belonging to the `AsyncEnumerable` class to be left as is rather than being transformed to the respective `IEnumerable` LINQ methods of the `Enumerable` class. This happened because of a change intended to avoid conversion of `EntityFrameworkQueryableExtensions` methods to `System.Linq.Queryable` when a compatible "Asyncless" method was already present among the EF Core extensions. 
This ended up also affecting the `IAsyncEnumerable` extensions, which for the most part lack the "Async" suffix so they were already deamed compatible and their transformation was skipped.

The fix consists in adding a condition that forces conversion when the containing type happens to be `AsyncEnumerable`.

fixes #118 