### PR TITLE
Keep statements that contain interior preprocessor directives

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1517,6 +1517,16 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         return result.WithTrailingTrivia(lastReturn.GetTrailingTrivia());
     }
 
+    /// <summary>
+    /// Checks whether the statement contains preprocessor directives anywhere past its leading
+    /// trivia (e.g. an <c>#endif</c> between the <c>if</c> header and its block). Dropping such
+    /// a statement would emit unbalanced directives, because only leading trivia is preserved.
+    /// </summary>
+    private static bool ContainsInteriorDirective(StatementSyntax statement)
+        => statement.DescendantTrivia()
+            .Skip(statement.GetLeadingTrivia().Count)
+            .Any(t => t.IsDirective);
+
     private static SyntaxTokenList StripAsyncModifier(SyntaxTokenList list)
         => TokenList(list.Where(z => !z.IsKind(SyntaxKind.AsyncKeyword)));
 
@@ -2117,7 +2127,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
                 dropOriginal = true;
             }
 
-            if (CanDropEmptyStatement(rewritten) || directiveStack.IsSyncOnly == false)
+            if ((CanDropEmptyStatement(rewritten) && !ContainsInteriorDirective(statement)) || directiveStack.IsSyncOnly == false)
             {
                 dropOriginal = true;
             }

--- a/tests/Generator.Tests/Snapshots/UnitTests.BrokenUsingStatement#g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.BrokenUsingStatement#g.verified.cs
@@ -1,0 +1,8 @@
+﻿//HintName: Test.Class.MethodAsync.g.cs
+#if MY_SPECIAL_SYMBOL
+using (var stream = new global::System.IO.MemoryStream())
+#else
+using (var stream2 = new global::System.IO.MemoryStream())
+#endif
+{
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.DirectiveInsideStatement#g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.DirectiveInsideStatement#g.verified.cs
@@ -1,8 +1,7 @@
 ﻿//HintName: Test.Class.MethodAsync.g.cs
+var bar =
 #if MY_SPECIAL_SYMBOL
-if (true)
+    true;
 #else
-if (true)
+    false;
 #endif
-{
-}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -701,7 +701,7 @@ if (true)
 #endif
 """.Verify(sourceType: SourceType.MethodBody);
 
-    [Fact(Skip = "Need to look into this more https://github.com/zompinc/sync-method-generator/issues/45#issuecomment-1893956960")]
+    [Fact]
     public Task BrokenIfStatement() => $$"""
 #if MY_SPECIAL_SYMBOL
 if (true)
@@ -710,6 +710,27 @@ if (true)
 #endif
 {
 }
+""".Verify(sourceType: SourceType.MethodBody);
+
+    [Fact]
+    public Task BrokenUsingStatement() => $$"""
+#if MY_SPECIAL_SYMBOL
+using (var stream = new global::System.IO.MemoryStream())
+#else
+using (var stream2 = new global::System.IO.MemoryStream())
+#endif
+{
+}
+""".Verify(sourceType: SourceType.MethodBody);
+
+    [Fact]
+    public Task DirectiveInsideStatement() => $$"""
+var bar =
+#if MY_SPECIAL_SYMBOL
+    true;
+#else
+    false;
+#endif
 """.Verify(sourceType: SourceType.MethodBody);
 
     [Fact]


### PR DESCRIPTION
## Problem

When an `#if`/`#else`/`#endif` block splits a statement - directives around the `if (...)` header with the block shared after `#endif` - the generator produced unbalanced directives and the generated file failed with CS1027:

```cs
#if MY_SPECIAL_SYMBOL
if (true)
#else
if (true)
#endif
{
}
```

generated:

```cs
#if MY_SPECIAL_SYMBOL
        if (true)
#else
            }
}
```

## Root cause

Roslyn attaches the `#if`/disabled text/`#else` to the active statement's leading trivia, but the `#endif` lands inside the statement (leading trivia of the `{` token). The cosmetic "prune empty `if`" heuristic (`CanDropEmptyStatement`) dropped the whole statement; the trivia-placeholder mechanism preserves leading-trivia directives only, so the interior `#endif` was destroyed.

## Fix

Suppress the empty-`if` pruning when the statement contains a directive past its leading trivia (`ContainsInteriorDirective`). The pruning is purely cosmetic, and keeping the statement preserves both the directive balance and the user's code verbatim.

The previously skipped `BrokenIfStatement` test now passes. Regression tests added for the `using` variant and for a declaration split by directives (#85's repro), both of which generate correct code on master already - the tests pin that behavior.

## Out of scope

Converting async code inside *inactive* branches (also raised in #45) is not feasible in general: no semantic model exists for disabled text, so calls there cannot be bound. Note that this is benign in practice - the generator runs per compilation with that compilation's symbols, so a branch disabled in the source is also disabled in that compilation's generated output. Statements split by `#if SYNC_ONLY` specifically (rather than user symbols) remain unsupported; a diagnostic for that case could be a follow-up.

Fixes #45
Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)