### PR TITLE
Create GitHub Releases with auto-generated changelog on publish

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Configures the notes GitHub auto-generates for each Release.
+# Categorization is by the labels applied to each merged pull request.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,8 @@ jobs:
     # secrets, so the release pipeline can't do anything useful for them.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to create the tag and GitHub Release
 
     steps:
       - name: Set path for nektos/act
@@ -230,3 +232,18 @@ jobs:
       - name: Push to NuGet
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_PUSH_KEY }}
+
+      - name: Create GitHub Release
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }} # gh infers the repo from this when no checkout is present
+        run: |
+          pkg=$(ls Zomp.SyncMethodGenerator.*.nupkg | head -1)
+          version=${pkg#Zomp.SyncMethodGenerator.}
+          version=${version%.nupkg}
+          gh release create "v$version" \
+            --target "$GITHUB_SHA" \
+            --title "v$version" \
+            --generate-notes \
+            ./*.nupkg


### PR DESCRIPTION
## What this does

When a release is cut (`workflow_dispatch` on `master`, the same trigger that pushes to NuGet), the workflow now also:

1. Derives the version from the produced `.nupkg`, so the tag stays in lockstep with the published package (next release would be `v2.0.x`).
1. Creates tag `v<version>` and a GitHub Release with `--generate-notes`, attaching the `.nupkg`.

`.github/release.yml` categorizes the generated notes by PR label (Features / Bug Fixes / Documentation / Dependencies / Other Changes, with `skip-changelog` excluded). Label PRs to populate the sections; unlabeled PRs fall under Other Changes.

## Notes for the first release

The repo currently has no tags, so the first release's notes will span the repo's full merged-PR history (16 PRs, verified via the `generate-notes` API preview). If a shorter debut is preferred, create a baseline tag on an older commit before dispatching the first release.

Auto-generated notes list merged PRs only; direct-to-master commits appear solely through the Full Changelog compare link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)