### PR TITLE
Fix generation stopping when the marker attribute is in multiple references

### DIFF
--- a/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
+++ b/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
@@ -156,13 +156,6 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             return null;
         }
 
-        var createSyncVersionAttribute = context.SemanticModel.Compilation.GetTypeByMetadataName(QualifiedCreateSyncVersionAttribute);
-        if (createSyncVersionAttribute == null)
-        {
-            // nothing to do if this type isn't available
-            return null;
-        }
-
         // find the index of the method in the containing type
         var index = 1;
 
@@ -182,34 +175,24 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             }
         }
 
-        var skipSyncVersionAttribute = context.SemanticModel.Compilation.GetTypeByMetadataName(QualifiedSkipSyncVersionAttribute);
-
         foreach (var attributeData in methodSymbol.GetAttributes())
         {
-            if (skipSyncVersionAttribute != null && skipSyncVersionAttribute.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
+            var attributeClassName = attributeData.AttributeClass?.ToDisplayString();
+
+            if (attributeClassName == QualifiedSkipSyncVersionAttribute)
             {
                 // Skip processing if the method has the skip attribute applied
                 return null;
             }
 
-            if (isTargetTypeSymbol && createSyncVersionAttribute.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
+            if (isTargetTypeSymbol && attributeClassName == QualifiedCreateSyncVersionAttribute)
             {
                 // Skip processing if the attribute is defined on the type to prioritize method-level attribute
                 return null;
             }
         }
 
-        AttributeData syncMethodGeneratorAttributeData = null!;
-        foreach (var attributeData in context.TargetSymbol.GetAttributes())
-        {
-            if (!createSyncVersionAttribute.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
-            {
-                continue;
-            }
-
-            syncMethodGeneratorAttributeData = attributeData;
-            break;
-        }
+        var syncMethodGeneratorAttributeData = context.Attributes[0];
 
         var classes = ImmutableArray.CreateBuilder<MethodParentDeclaration>();
         SyntaxNode? node = methodDeclarationSyntax;

--- a/tests/Generator.Tests/MultipleAttributeDefinitionsTests.cs
+++ b/tests/Generator.Tests/MultipleAttributeDefinitionsTests.cs
@@ -1,0 +1,90 @@
+using Basic.Reference.Assemblies;
+using Zomp.SyncMethodGenerator;
+
+namespace Generator.Tests;
+
+/// <summary>
+/// Verifies generation when the marker attribute is compiled into more than one referenced assembly.
+/// This happens in a chain of projects which use <c>InternalsVisibleTo</c> together with
+/// <c>SYNC_METHOD_GENERATOR_DISABLE_ATTRIBUTE_GENERATION</c>.
+/// </summary>
+public class MultipleAttributeDefinitionsTests
+{
+    private const string DisableAttributeGeneration = "SYNC_METHOD_GENERATOR_DISABLE_ATTRIBUTE_GENERATION";
+
+    [Fact]
+    public void GenerateWhenAttributeIsDefinedInMultipleReferences()
+    {
+        // Each library bakes in its own internal copy of the marker attribute. Only the second one
+        // exposes its internals to the consumer, so the attribute usage below still binds uniquely.
+        var first = CreateLibraryWithAttribute("First", Net100.References.All, "Second");
+        var second = CreateLibraryWithAttribute("Second", [.. Net100.References.All, first], "Consumer");
+
+        var parseOptions = CSharpParseOptions.Default
+            .WithLanguageVersion(LanguageVersion.Preview)
+            .WithPreprocessorSymbols(DisableAttributeGeneration);
+
+        var source = """
+using System.Threading.Tasks;
+
+namespace Consuming;
+
+public partial class Class
+{
+    [Zomp.SyncMethodGenerator.CreateSyncVersion]
+    public async Task MethodAsync() => await Task.CompletedTask;
+}
+""";
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Consumer",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source, parseOptions)],
+            references: [.. Net100.References.All, first, second],
+            options: new(OutputKind.DynamicallyLinkedLibrary));
+
+        var result = CSharpGeneratorDriver
+            .Create(new SyncMethodSourceGenerator())
+            .WithUpdatedParseOptions(parseOptions)
+            .RunGenerators(compilation)
+            .GetRunResult();
+
+        var generated = Assert.Single(
+            result.GeneratedTrees.Where(t => t.FilePath.EndsWith("Consuming.Class.MethodAsync.g.cs", StringComparison.Ordinal)));
+
+        Assert.Contains("public void Method()", generated.ToString(), StringComparison.Ordinal);
+
+        var errors = compilation.AddSyntaxTrees(result.GeneratedTrees)
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+
+        Assert.Empty(errors);
+    }
+
+    private static PortableExecutableReference CreateLibraryWithAttribute(
+        string assemblyName,
+        IEnumerable<MetadataReference> references,
+        params string[] internalsVisibleTo)
+    {
+        var source = string.Join(
+            Environment.NewLine,
+            internalsVisibleTo.Select(a => $"""[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("{a}")]"""));
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // The generator contributes its own internal copy of the marker attribute to this assembly.
+        _ = CSharpGeneratorDriver
+            .Create(new SyncMethodSourceGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out var withAttribute, out _);
+
+        using var peStream = new MemoryStream();
+        var emitResult = withAttribute.Emit(peStream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        peStream.Position = 0;
+        return MetadataReference.CreateFromStream(peStream);
+    }
+}

--- a/tests/Generator.Tests/MultipleAttributeDefinitionsTests.cs
+++ b/tests/Generator.Tests/MultipleAttributeDefinitionsTests.cs
@@ -15,16 +15,7 @@ public class MultipleAttributeDefinitionsTests
     [Fact]
     public void GenerateWhenAttributeIsDefinedInMultipleReferences()
     {
-        // Each library bakes in its own internal copy of the marker attribute. Only the second one
-        // exposes its internals to the consumer, so the attribute usage below still binds uniquely.
-        var first = CreateLibraryWithAttribute("First", Net100.References.All, "Second");
-        var second = CreateLibraryWithAttribute("Second", [.. Net100.References.All, first], "Consumer");
-
-        var parseOptions = CSharpParseOptions.Default
-            .WithLanguageVersion(LanguageVersion.Preview)
-            .WithPreprocessorSymbols(DisableAttributeGeneration);
-
-        var source = """
+        var (compilation, result) = RunGenerator("""
 using System.Threading.Tasks;
 
 namespace Consuming;
@@ -34,7 +25,53 @@ public partial class Class
     [Zomp.SyncMethodGenerator.CreateSyncVersion]
     public async Task MethodAsync() => await Task.CompletedTask;
 }
-""";
+""");
+
+        var generated = Assert.Single(GeneratedFor(result, "MethodAsync"));
+        Assert.Contains("public void Method()", generated.ToString(), StringComparison.Ordinal);
+
+        var errors = compilation.AddSyntaxTrees(result.GeneratedTrees)
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void SkipAttributeIsHonoredWhenAttributesAreDefinedInMultipleReferences()
+    {
+        var (_, result) = RunGenerator("""
+using System.Threading.Tasks;
+
+namespace Consuming;
+
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public partial class Class
+{
+    public async Task IncludedAsync() => await Task.CompletedTask;
+
+    [Zomp.SyncMethodGenerator.SkipSyncVersion]
+    public async Task ExcludedAsync() => await Task.CompletedTask;
+}
+""");
+
+        _ = Assert.Single(GeneratedFor(result, "IncludedAsync"));
+        Assert.Empty(GeneratedFor(result, "ExcludedAsync"));
+    }
+
+    private static IEnumerable<SyntaxTree> GeneratedFor(GeneratorDriverRunResult result, string methodName)
+        => result.GeneratedTrees.Where(t => t.FilePath.EndsWith($"Consuming.Class.{methodName}.g.cs", StringComparison.Ordinal));
+
+    private static (CSharpCompilation Compilation, GeneratorDriverRunResult Result) RunGenerator(string source)
+    {
+        // Each library bakes in its own internal copy of the marker attributes. Only the second one
+        // exposes its internals to the consumer, so attribute usages still bind uniquely.
+        var first = CreateLibraryWithAttribute("First", Net100.References.All, "Second");
+        var second = CreateLibraryWithAttribute("Second", [.. Net100.References.All, first], "Consumer");
+
+        var parseOptions = CSharpParseOptions.Default
+            .WithLanguageVersion(LanguageVersion.Preview)
+            .WithPreprocessorSymbols(DisableAttributeGeneration);
 
         var compilation = CSharpCompilation.Create(
             assemblyName: "Consumer",
@@ -48,16 +85,7 @@ public partial class Class
             .RunGenerators(compilation)
             .GetRunResult();
 
-        var generated = Assert.Single(
-            result.GeneratedTrees.Where(t => t.FilePath.EndsWith("Consuming.Class.MethodAsync.g.cs", StringComparison.Ordinal)));
-
-        Assert.Contains("public void Method()", generated.ToString(), StringComparison.Ordinal);
-
-        var errors = compilation.AddSyntaxTrees(result.GeneratedTrees)
-            .GetDiagnostics()
-            .Where(d => d.Severity == DiagnosticSeverity.Error);
-
-        Assert.Empty(errors);
+        return (compilation, result);
     }
 
     private static PortableExecutableReference CreateLibraryWithAttribute(


### PR DESCRIPTION
## Problem

In a chain of 3+ projects using `InternalsVisibleTo` together with `SYNC_METHOD_GENERATOR_DISABLE_ATTRIBUTE_GENERATION`, the last project silently generates nothing - no code, no diagnostic. Reported in #76.

## Root cause

The first two projects each compile in their own `internal` copy of `Zomp.SyncMethodGenerator.CreateSyncVersionAttribute`. Because `ProjectReference`s are transitive, the third project's compilation sees both copies.

`ForAttributeWithMetadataName` still fires - ordinary C# binding discards the inaccessible copy and binds the attribute usage uniquely. But `GetMethodToGenerate` then called `Compilation.GetTypeByMetadataName`, which returns **null** when several referenced assemblies declare the same fully qualified type (it does not consider accessibility for non-well-known types). That null hit the `// nothing to do if this type isn't available` early return.

This matches the reports in the issue thread: removing one of the two `ProjectReference`s fixes it, and two-project chains were never affected.

## Fix

The lookup is redundant - `ForAttributeWithMetadataName` firing already proves the attribute exists and bound. Remove it, and compare attribute classes by display string, which is the same approach `AsyncToSyncRewriter.IsCreateSyncVersionAttribute` already uses and is copy-agnostic. `context.Attributes[0]` replaces a hand-rolled scan (which also carried a `null!` NRE hazard).

Also repairs a latent sibling bug: `SkipSyncVersionAttribute` resolution failed the same way, so `[SkipSyncVersion]` was silently ignored whenever the attribute was ambiguous.

## Verification

First commit adds a failing test that builds two library assemblies (each with its own baked-in attribute copy, chained via `InternalsVisibleTo`) and a consumer referencing both; it asserts generation happens and the result compiles. It fails on master with "the collection was empty" and passes with the fix.

Verified independently against a real 3-project repro built per the issue: before the fix project 3 emitted nothing and failed `CS0535`; after, it generates and the solution builds clean.

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)