### PR TITLE
Fix null-coalescing statements being dropped entirely

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -605,6 +605,15 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
             return UnwrapExtension(@base, changeMemoryToSpan, reducedFromExtensionMethod, replaceInInvocation.Pop());
         }
 
+        // Rename direct invocation through conditional access eg. bar?.BarBarAsync()
+        if (@base.Expression is MemberBindingExpressionSyntax mbe
+            && reducedFromExtensionMethod is null
+            && node.Expression is MemberBindingExpressionSyntax originalMbe
+            && ReplaceAsync(originalMbe.Name) is { } memberBindingNewName)
+        {
+            return @base.WithExpression(mbe.WithName(mbe.ChangeIdentifier(memberBindingNewName)));
+        }
+
         if (changeMemoryToSpan && reducedFromExtensionMethod is null && !endsWithMemory)
         {
             return AppendSpan(@base);
@@ -687,8 +696,10 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
     /// <inheritdoc/>
     public override SyntaxNode? VisitParenthesizedExpression(ParenthesizedExpressionSyntax node)
     {
-        var dropParentheses = node.Expression is AwaitExpressionSyntax && node.Parent is not InterpolationSyntax;
         var @base = (ParenthesizedExpressionSyntax)base.VisitParenthesizedExpression(node)!;
+        var dropParentheses = node.Parent is not InterpolationSyntax
+            && (node.Expression is AwaitExpressionSyntax
+                || (node.Expression.IsKind(SyntaxKind.CoalesceExpression) && @base.Expression is not BinaryExpressionSyntax));
         return dropParentheses ? @base.Expression.WithTriviaFrom(@base) : @base;
     }
 
@@ -1368,6 +1379,25 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
     public override SyntaxNode? VisitBinaryExpression(BinaryExpressionSyntax node)
     {
         var @base = (BinaryExpressionSyntax)base.VisitBinaryExpression(node)!;
+
+        // For task-valued null coalescing (eg. await (t?.DoAsync() ?? Task.CompletedTask)),
+        // reduce to the side which has a synchronized version when the other side has none.
+        if (node.IsKind(SyntaxKind.CoalesceExpression)
+            && semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol { IsNonGenericTaskOrValueTask: true })
+        {
+            var removeLeft = ShouldRemoveArgument(node.Left);
+            var removeRight = ShouldRemoveArgument(node.Right);
+
+            if (removeRight && !removeLeft)
+            {
+                return @base.Left.WithTriviaFrom(@base);
+            }
+
+            if (removeLeft && !removeRight)
+            {
+                return @base.Right.WithTriviaFrom(@base);
+            }
+        }
 
         if (@base.OperatorToken.IsKind(SyntaxKind.IsKeyword) || @base.OperatorToken.IsKind(SyntaxKind.AsKeyword))
         {
@@ -2287,6 +2317,7 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
     private bool ShouldRemoveArgument(ExpressionSyntax expr, RemoveArgumentContext context) => expr switch
     {
         ElementAccessExpressionSyntax ee => ShouldRemoveArgument(ee.Expression, context),
+        BinaryExpressionSyntax be when be.IsKind(SyntaxKind.CoalesceExpression) => ShouldRemoveArgument(be.Left, context) && ShouldRemoveArgument(be.Right, context),
         BinaryExpressionSyntax be => ShouldRemoveArgument(be.Left, context) || ShouldRemoveArgument(be.Right, context),
         CastExpressionSyntax ce => HasSymbolAndShouldBeRemoved(expr) || ShouldRemoveArgument(ce.Expression, context),
         ParenthesizedExpressionSyntax pe => ShouldRemoveArgument(pe.Expression, context),

--- a/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithCompletedTask#Bark.BarBarAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithCompletedTask#Bark.BarBarAsync.g.verified.cs
@@ -1,0 +1,7 @@
+﻿//HintName: Test.Class.Bark.BarBarAsync.g.cs
+public partial class Bark
+{
+    public void BarBar()
+    {
+    }
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithCompletedTask#FooFooAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithCompletedTask#FooFooAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.FooFooAsync.g.cs
+public void FooFoo(global::Test.Class.Bark? bar)
+{
+    bar?.BarBar();
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithPendingTask#Bark.BarBarAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithPendingTask#Bark.BarBarAsync.g.verified.cs
@@ -1,0 +1,7 @@
+﻿//HintName: Test.Class.Bark.BarBarAsync.g.cs
+public partial class Bark
+{
+    public void BarBar()
+    {
+    }
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithPendingTask#FooFooAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.AwaitNullCoalescingWithPendingTask#FooFooAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.FooFooAsync.g.cs
+public void FooFoo(global::Test.Class.Bark bar)
+{
+    bar.BarBar();
+}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -807,6 +807,42 @@ public static async Task MethodAsync(IAsyncEnumerator<byte> bufferIterator)
 """.Verify();
 
     [Fact]
+    public Task AwaitNullCoalescingWithCompletedTask() => """
+[CreateSyncVersion]
+public async Task FooFooAsync(Bark? bar)
+{
+    await (bar?.BarBarAsync() ?? Task.CompletedTask);
+}
+
+public partial class Bark
+{
+    [CreateSyncVersion]
+    public async Task BarBarAsync()
+    {
+    }
+}
+""".Verify();
+
+    [Fact]
+    public Task AwaitNullCoalescingWithPendingTask() => """
+private Task? pending;
+
+[CreateSyncVersion]
+public async Task FooFooAsync(Bark bar)
+{
+    await (pending ?? bar.BarBarAsync());
+}
+
+public partial class Bark
+{
+    [CreateSyncVersion]
+    public async Task BarBarAsync()
+    {
+    }
+}
+""".Verify();
+
+    [Fact]
     public Task DropReturnStatementWhenNonGenericTaskIsReturned() => """
 [CreateSyncVersion]
 public Task MethodAsync()


### PR DESCRIPTION
## Problem

Reported in #112. This method generates an empty body:

```cs
public async Task FooFooAsync(Bark? bar)
{
    await (bar?.BarBarAsync() ?? Task.CompletedTask);
}
```

## Root cause

Two defects, both needed for correct output.

**1. The statement is dropped.** `??` is a `BinaryExpressionSyntax`, and `ShouldRemoveArgument` removes a binary expression when *either* operand is removable. `Task.CompletedTask` is removable, so the whole statement went away even though the left operand does real work. That "either" rule is right for most operators but wrong for coalescing, where a removable operand is merely the fallback - the expression is only dead when *both* sides are. (The neighbouring `ConditionalExpressionSyntax` arm already uses `&&` for the same reason.)

Coalescing now requires both sides, and a task-valued coalesce reduces to whichever side survives.

**2. Conditional-access invocations were never renamed.** Once the statement survived, it emitted `bar?.BarBarAsync();` - still calling the async method. `VisitInvocationExpression` renamed identifier, generic-name and member-access expressions, but `bar?.BarBarAsync()` is a `MemberBindingExpressionSyntax`, which only had an extension-method path. This is a latent bug well beyond this issue: *any* `x?.SomethingAsync()` was left un-renamed. Renaming goes through `ReplaceAsync`, so the `WaitAsync`-on-`Task` exclusion still applies, and it is guarded to leave the extension-method chain path alone.

Output is now what the issue expects:

```cs
public void FooFoo(global::Test.Bark? bar)
{
    bar?.BarBar();
}
```

## Verification

First commit adds the failing test with the expected snapshot; it fails on master with an empty body and passes with the fix. Full suite green on both target frameworks, with no changes to any existing snapshot.

The main behavioural widening to be aware of: an argument like `Method(nullableToken ?? default)` for a removable parameter was previously judged removable from the left side alone and now needs both sides. No existing test covers that shape and no snapshot moved.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)