### PR TITLE
Keep calls to generic methods which return their own type parameter

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -863,10 +863,14 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         var isFunc = node.Parent is { } parent
             && semanticModel.GetTypeInfo(parent).Type is INamedTypeSymbol { IsGenericType: true, IsSystemFunc: true } n;
 
+        // Generic method type arguments like Bar<Task<T>> are unwrapped to Bar<T>, not removed
+        var isMethodTypeArgumentList = node.Parent is GenericNameSyntax gn && GetSymbol(gn) is IMethodSymbol;
+
         // Do not remove Task<T>, but remove Task inside a Func<>
         bool RemoveType(TypeSyntax z, int index) =>
             !(isFunc && index == node.Arguments.Count - 1 && z is GenericNameSyntax)
             && semanticModel.GetTypeInfo(z).Type is { } type
+            && !(isMethodTypeArgumentList && type is INamedTypeSymbol { IsTaskOrValueTask: true, IsGenericType: true })
             && ShouldRemoveType(type);
 
         var indicesToRemove = node.Arguments.GetIndices(RemoveType);
@@ -1917,7 +1921,8 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         IPropertySymbol { IsCancellationRequested: true } => !isNegated,
         IMethodSymbol ms =>
             IsSpecialMethod(ms) is SpecialMethod.None or SpecialMethod.Drop
-                && ((ShouldRemoveType(ms.ReturnType, isArgument: true) && ms.MethodKind != MethodKind.LocalFunction)
+                && ((ShouldRemoveType(ms.ReturnType, isArgument: true) && ms.MethodKind != MethodKind.LocalFunction
+                        && ms.OriginalDefinition.ReturnType is not ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method })
                     || (ms.ReceiverType is { } receiver && ShouldRemoveType(receiver, isArgument: true)))
                 && !HasSyncMethod(ms),
         _ => ShouldRemoveType(GetReturnType(symbol), isArgument: true),

--- a/tests/Generator.Tests/Snapshots/UnitTests.GenericMethodInferringTaskTypeArgument#FooAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.GenericMethodInferringTaskTypeArgument#FooAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.FooAsync.g.cs
+public bool Foo()
+{
+    return Bar(() => true);
+}

--- a/tests/Generator.Tests/Snapshots/UnitTests.GenericMethodWithExplicitTaskTypeArgument#FooAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/UnitTests.GenericMethodWithExplicitTaskTypeArgument#FooAsync.g.verified.cs
@@ -1,0 +1,5 @@
+﻿//HintName: Test.Class.FooAsync.g.cs
+public bool Foo()
+{
+    return Bar<bool>(() => true);
+}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -53,6 +53,28 @@ namespace M
 """.Verify(sourceType: SourceType.Full);
 
     [Fact]
+    public Task GenericMethodInferringTaskTypeArgument() => """
+[CreateSyncVersion]
+public async Task<bool> FooAsync()
+{
+    return await Bar(() => Task.FromResult(true));
+}
+
+public T Bar<T>(Func<T> innerLogic) => innerLogic();
+""".Verify();
+
+    [Fact]
+    public Task GenericMethodWithExplicitTaskTypeArgument() => """
+[CreateSyncVersion]
+public async Task<bool> FooAsync()
+{
+    return await Bar<Task<bool>>(() => Task.FromResult(true));
+}
+
+public T Bar<T>(Func<T> innerLogic) => innerLogic();
+""".Verify();
+
+    [Fact]
     public Task MultipleNamespaces() => """
 namespace NsOne
 {


### PR DESCRIPTION
## Problem

Reported in #106:

```cs
[CreateSyncVersion]
public async Task<bool> FooAsync()
{
    return await Bar(() => Task.FromResult(true));
}

public T Bar<T>(Func<T> innerLogic) => innerLogic();
```

generates `public bool Foo() { }` - the return statement vanishes and the method fails with CS0161.

## Root cause

`ShouldRemoveArgument(ISymbol)` asks whether the method's return type should be removed. With `T` inferred as `Task<bool>`, the *constructed* return type is `Task<bool>`, which implements `IAsyncResult` and so counts as removable - and the whole statement goes.

But that task-ness comes purely from call-site inference; the method itself declares `T`. The call site is rewritable: the lambda body `Task.FromResult(true)` is already unwrapped to `true` by the existing `SpecialMethod.FromResult` handling, which re-infers `T` as `bool`. So the call must be kept, not dropped.

The fix exempts methods whose **declared** return type is a method-owned type parameter. Scoping to `TypeParameterKind.Method` is essential: a delegate such as `Func<CancellationToken, Task<bool>>.Invoke` also has a type parameter as its original return type, but that one is fixed at the property declaration and those invocations must still be dropped. (A first attempt without the restriction regressed 8 tests.)

A second defect surfaced with an explicitly written type argument: `VisitGenericName` already unwraps `Bar<Task<bool>>` to `Bar<bool>`, but `VisitTypeArgumentList` then removed the argument outright, emitting `Bar<>`. Generic `Task<T>`/`ValueTask<T>` arguments of a generic **method** invocation are now kept.

Output now matches the issue's expectation:

```cs
public bool Foo() { return Bar(() => true); }        // inferred
public bool Foo() { return Bar<bool>(() => true); }  // explicit
```

## Verification

First commit adds both failing tests; on master they fail with CS0161. Full suite green on both target frameworks after the fix, with no changes to existing snapshots.

## Known edge, not addressed

`Bar<Task>(...)` with the non-generic `Task` as an explicit type argument has no sync equivalent (`T = void` is not expressible). With this change the statement is kept and the type argument still removed, which can produce uncompilable output where it was previously dropped silently. No test covers that shape; it deserves its own decision between dropping and reporting a diagnostic.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)