### PR TITLE
Report a diagnostic for Task.WhenAll and Task.WhenAny

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Zomp.SyncMethodGenerator/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 ZSMGEN001 | Preprocessor | Error | DiagnosticMessages
 ZSMGEN002 | Preprocessor | Error | DiagnosticMessages
 ZSMGEN003 | Preprocessor | Error | DiagnosticMessages
+ZSMGEN004 | Usage | Error | DiagnosticMessages

--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -37,6 +37,8 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
     private const string Delay = nameof(Task<>.Delay);
     private const string FromResult = nameof(Task<>.FromResult);
     private const string WaitAsync = "WaitAsync";
+    private const string WhenAll = nameof(Task.WhenAll);
+    private const string WhenAny = nameof(Task.WhenAny);
     private const string IsCancellationRequested = nameof(CancellationToken.IsCancellationRequested);
     private const string MoveNextAsync = nameof(IAsyncEnumerator<>.MoveNextAsync);
     private const string DisposeAsync = nameof(IAsyncEnumerator<>.DisposeAsync);
@@ -552,6 +554,13 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         if (symbol is not IMethodSymbol methodSymbol)
         {
             throw new InvalidOperationException($"Could not get symbol of {node}");
+        }
+
+        if (IsCombinator(methodSymbol))
+        {
+            // Dropping the call would silently discard the work it waits on, so refuse the method.
+            diagnostics.Add(ReportedDiagnostic.Create(NoSynchronousEquivalent, node.GetLocation(), methodSymbol.Name));
+            return base.VisitInvocationExpression(node);
         }
 
         var changeMemoryToSpan = methodSymbol.ReturnType is INamedTypeSymbol { IsMemory: true }
@@ -1499,6 +1508,13 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
             }
         }
     }
+
+    /// <summary>
+    /// Checks for the task combinators, which wait on several operations at once. Synchronous
+    /// code has no equivalent: the operations have already run to completion one by one.
+    /// </summary>
+    private static bool IsCombinator(IMethodSymbol methodSymbol)
+        => methodSymbol is { Name: WhenAll or WhenAny, ContainingType.IsNonGenericTaskOrValueTask: true };
 
     private static SpecialMethod IsSpecialMethod(IMethodSymbol methodSymbol) => methodSymbol switch
     {

--- a/src/Zomp.SyncMethodGenerator/DiagnosticMessages.cs
+++ b/src/Zomp.SyncMethodGenerator/DiagnosticMessages.cs
@@ -26,5 +26,15 @@ internal static class DiagnosticMessages
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    internal static readonly DiagnosticDescriptor NoSynchronousEquivalent = new(
+        id: "ZSMGEN004",
+        title: "Method has no synchronous equivalent",
+        messageFormat: $"Cannot synchronize '{{0}}'. It waits on several operations at once, which has no synchronous equivalent. Provide a synchronous implementation in an #if {AsyncToSyncRewriter.SyncOnly} region.",
+        category: Usage,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     private const string Preprocessor = "Preprocessor";
+
+    private const string Usage = "Usage";
 }

--- a/tests/Generator.Tests/Snapshots/TaskTests.ReportWhenAll.verified.txt
+++ b/tests/Generator.Tests/Snapshots/TaskTests.ReportWhenAll.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: : (6,14)-(6,50),
+      Message: Cannot synchronize 'WhenAll'. It waits on several operations at once, which has no synchronous equivalent. Provide a synchronous implementation in an #if SYNC_ONLY region.,
+      Severity: Error,
+      Descriptor: {
+        Id: ZSMGEN004,
+        Title: Method has no synchronous equivalent,
+        MessageFormat: Cannot synchronize '{0}'. It waits on several operations at once, which has no synchronous equivalent. Provide a synchronous implementation in an #if SYNC_ONLY region.,
+        Category: Usage,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/tests/Generator.Tests/Snapshots/TaskTests.ReportWhenAny.verified.txt
+++ b/tests/Generator.Tests/Snapshots/TaskTests.ReportWhenAny.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: : (6,18)-(6,54),
+      Message: Cannot synchronize 'WhenAny'. It waits on several operations at once, which has no synchronous equivalent. Provide a synchronous implementation in an #if SYNC_ONLY region.,
+      Severity: Error,
+      Descriptor: {
+        Id: ZSMGEN004,
+        Title: Method has no synchronous equivalent,
+        MessageFormat: Cannot synchronize '{0}'. It waits on several operations at once, which has no synchronous equivalent. Provide a synchronous implementation in an #if SYNC_ONLY region.,
+        Category: Usage,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/tests/Generator.Tests/TaskTests.cs
+++ b/tests/Generator.Tests/TaskTests.cs
@@ -41,4 +41,28 @@ public async Task MethodAsync(Task task, CancellationToken ct)
     await task.ConfigureAwait(false);
 }
 """.Verify();
+
+    [Fact]
+    public Task ReportWhenAll() => """
+[CreateSyncVersion]
+public async Task MethodAsync()
+{
+    await Task.WhenAll(FooAsync(), FooAsync());
+}
+
+private async Task FooAsync() => await Task.CompletedTask;
+private void Foo() { }
+""".Verify();
+
+    [Fact]
+    public Task ReportWhenAny() => """
+[CreateSyncVersion]
+public async Task MethodAsync()
+{
+    _ = await Task.WhenAny(FooAsync(), FooAsync());
+}
+
+private async Task FooAsync() => await Task.CompletedTask;
+private void Foo() { }
+""".Verify();
 }


### PR DESCRIPTION
## Problem

#101 reports a method which "completely fails". It races two async enumerators with `Task.WhenAny`, and the generated synchronous version is worse than a compile error - it is an infinite loop:

```cs
var move1 = e1.MoveNext();
var move2 = e2.MoveNext();
while (true)
{
}                                 // the whole loop body was dropped
```

`Task.WhenAll` behaves the same way: the statement disappears and the work it waited on goes with it.

## Why it happens

Both return a `Task`, and every `Task` implements `IAsyncResult`, which `ShouldRemoveType` treats as removable - the same rule that drops `CancellationToken` and `IProgress<T>` arguments. So the call is deleted, and with it any statement whose condition depended on it.

## Why it is not translated instead

Waiting on several operations at once has no synchronous equivalent. Synchronous code has already run each operation to completion, one after another, by the time it reaches the call. `WhenAny` asks which finished first, a question that no longer has a meaningful answer; translating it would have to invent an ordering. `WhenAll` could in principle become sequential statements, but that silently changes concurrency into sequence and needs statement-level expansion of an expression. Both commenters on the issue reached the same conclusion.

## What this does

Report `ZSMGEN004` when the invocation is `Task.WhenAll` or `Task.WhenAny`, pointing at `#if SYNC_ONLY` as the way to supply a synchronous implementation by hand. The existing error gate in `RegisterSourceOutput` then suppresses the generated file, so nothing misleading is emitted.

`Task.WaitAll` and `Task.WaitAny` are untouched - they are already synchronous.

## Compatibility

Code containing these calls used to be mistranslated in silence and will now fail the build. That is the intent: the previous output compiled, or nearly did, while doing something the author never wrote. No test in the suite covered either method, which is consistent with nobody having relied on the old behaviour deliberately.

## Verification

First commit adds both tests with the expected snapshots and fails on master. Full suite green on both target frameworks after the fix. The rule is registered in `AnalyzerReleases.Unshipped.md`, which the release-tracking analyzer enforces.

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)