### PR TITLE
Remove unused packages and update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,21 +1,19 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.9" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="Fody" Version="6.6.4" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.10" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <!-- <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="5.0.0" /> -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="N.SourceGenerators.UnionTypes" Version="0.28.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="PolySharp" Version="1.16.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Runtime.Experimental" Version="6.0.2" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
`dotnet outdated` plus a check of what is actually referenced. Consolidates what started as three separate pull requests.

## Removed

`Fody` and `System.Runtime.Experimental` were declared in `Directory.Packages.props` and referenced by no project - no `PackageReference` anywhere, no `FodyWeavers.xml`. `System.Runtime.Experimental` was the preview of generic math, which shipped for real in .NET 7.

Worth knowing: `dotnet outdated` cannot find entries like these. It reports on what is referenced, so a version entry with no reference is invisible to it.

## Updated

| Package | From | To |
| --- | --- | --- |
| Basic.Reference.Assemblies.Net100 | 1.8.9 | 1.8.10 |
| coverlet.collector | 8.0.1 | 10.0.1 |
| Microsoft.Bcl.AsyncInterfaces | 10.0.6 | 10.0.10 |
| Microsoft.CodeAnalysis.NetAnalyzers | 10.0.202 | 10.0.302 |
| Microsoft.EntityFrameworkCore | 10.0.6 | 10.0.10 |
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.8.1 |
| Microsoft.SourceLink.GitHub | 10.0.202 | 10.0.301 |
| PolySharp | 1.15.0 | 1.16.0 |

All test or build time only - nothing here changes what is published.

Two of them needed more than a green build to trust:

**coverlet** crosses two majors, so `tests/coverlet.runsettings` could have been silently ignored. It is not. On the same tree, 8.0.1 gave 97.85% over 1910 lines and 10.0.1 gives 97.86% over 1922, the difference being code added in between. The report still contains only the generator assembly and no `*.g.cs` classes, so `Exclude`, `ExcludeByFile` and `IncludeTestAssembly` all still take effect - which matters because codecov consumes that file.

**The analyzers** bring new rules, and with `TreatWarningsAsErrors` those arrive as a failed build rather than as warnings. Debug and Release both build with no warnings.

## Left alone

`Microsoft.CodeAnalysis.CSharp` stays pinned to exactly `[5.0.0]`. It sets the lowest Roslyn a consumer needs, and `Directory.Build.targets` overrides it per Roslyn variant build, so it is a compatibility decision rather than an upgrade.

The commented out `Microsoft.Net.Compilers.Toolset` entry stays - it is commented consistently in the props file and both project files, which is a deliberate escape hatch.

Nerdbank.GitVersioning is in #139 on its own, because a bad version stamp there would not fail CI - it would surface later as a mis-tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)