### PR TITLE
Update Microsoft.CodeAnalysis.NetAnalyzers to 10.0.302

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Fody" Version="6.6.4" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
     <!-- <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="5.0.0" /> -->


### PR DESCRIPTION
On its own because a new analyzer version brings new rules, and with `TreatWarningsAsErrors` those arrive as a failed build rather than as warnings. If this one breaks something it should be obvious which change did it.

As it turns out the tree is clean: Debug and Release both build with no warnings and no errors, and the tests pass on both target frameworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)