### PR TITLE
Update Nerdbank.GitVersioning to 3.10.91

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="N.SourceGenerators.UnionTypes" Version="0.28.2" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="PolySharp" Version="1.16.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />


### PR DESCRIPTION
On its own because this package decides the version stamped on the assembly and on the package, and the release workflow added in #126 reads that version back from the nupkg file name to create the tag. A surprise here would show up as a mis-tagged release rather than as a build failure.

Verified that the computed version does not move. At the same commit, both the old and the new version produce:

```
AssemblyVersion               2.0.28.22741
AssemblyInformationalVersion  2.0.28+58d59ad482
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)