### PR TITLE
Key the NuGet cache on files which exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,9 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          # Versions live in Directory.Packages.props, and which packages each project
+          # asks for lives in the project files. There are no lock files to hash.
+          key: ${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
       - name: Restore dependencies


### PR DESCRIPTION
The cache key hashed `**/packages.lock.json`, and this repository has no lock files:

```yaml
key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
```

`hashFiles` returns an empty string when nothing matches, so the key was the constant `{os}-nuget-`. The cache was written on the first run and restored on every run after that, never noticing that the dependencies had changed - which also means the package updates in the other open pull requests would have restored a cache that predates them.

Hash the files which actually describe the dependencies instead: `Directory.Packages.props` for the versions, and the project files for which packages each project asks for.

The alternative would be to turn on `RestorePackagesWithLockFile` and hash the lock files for real. That is a bigger change with its own maintenance, and worth doing separately if you want restore to be genuinely reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)