### PR TITLE
Report overloads which collide once synchronized

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Zomp.SyncMethodGenerator/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ ZSMGEN001 | Preprocessor | Error | DiagnosticMessages
 ZSMGEN002 | Preprocessor | Error | DiagnosticMessages
 ZSMGEN003 | Preprocessor | Error | DiagnosticMessages
 ZSMGEN004 | Usage | Error | DiagnosticMessages
+ZSMGEN005 | Usage | Error | DiagnosticMessages

--- a/src/Zomp.SyncMethodGenerator/DiagnosticMessages.cs
+++ b/src/Zomp.SyncMethodGenerator/DiagnosticMessages.cs
@@ -34,6 +34,14 @@ internal static class DiagnosticMessages
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    internal static readonly DiagnosticDescriptor CollidingOverloads = new(
+        id: "ZSMGEN005",
+        title: "Overloads collide once synchronized",
+        messageFormat: "Cannot synchronize this overload. It produces '{0}', which another overload in the same type also produces. Apply [SkipSyncVersion] to all but one of them.",
+        category: Usage,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     private const string Preprocessor = "Preprocessor";
 
     private const string Usage = "Usage";

--- a/src/Zomp.SyncMethodGenerator/MethodToGenerate.cs
+++ b/src/Zomp.SyncMethodGenerator/MethodToGenerate.cs
@@ -13,6 +13,7 @@
 /// <param name="DisableNullable">Disables nullable for the method.</param>
 /// <param name="Diagnostics">Diagnostics.</param>
 /// <param name="HasErrors">True if there are errors in <see cref="Diagnostics"/>.</param>
+/// <param name="Signature">Signature the synchronized method will be emitted with, used to detect colliding overloads.</param>
 internal sealed record MethodToGenerate(
     int Index,
     EquatableArray<string> Namespaces,
@@ -23,4 +24,5 @@ internal sealed record MethodToGenerate(
     string Implementation,
     bool DisableNullable,
     EquatableArray<ReportedDiagnostic> Diagnostics,
-    bool HasErrors);
+    bool HasErrors,
+    SynchronizedSignature? Signature);

--- a/src/Zomp.SyncMethodGenerator/Models/SynchronizedSignature.cs
+++ b/src/Zomp.SyncMethodGenerator/Models/SynchronizedSignature.cs
@@ -1,0 +1,33 @@
+namespace Zomp.SyncMethodGenerator.Models;
+
+/// <summary>
+/// The signature a synchronized method will be emitted with, and where the method it came from
+/// was written. Two methods sharing a <see cref="Key"/> cannot both be emitted: the compiler
+/// would see the same member declared twice.
+/// </summary>
+/// <param name="Key">Fully qualified signature of the method which will be emitted.</param>
+/// <param name="FilePath">File path of the method being synchronized.</param>
+/// <param name="TextSpan">Text span of the method being synchronized.</param>
+/// <param name="LineSpan">Line span of the method being synchronized.</param>
+internal sealed record SynchronizedSignature(string Key, string FilePath, TextSpan TextSpan, LinePositionSpan LineSpan)
+{
+    /// <summary>
+    /// Compares by <see cref="Key"/> alone. The spans move whenever anything above the method is
+    /// edited, and letting that reach the incremental pipeline would defeat caching for a method
+    /// whose generated output has not changed at all.
+    /// </summary>
+    /// <param name="other">Signature to compare against.</param>
+    /// <returns>True if both describe the same emitted member.</returns>
+    public bool Equals(SynchronizedSignature? other)
+        => other is not null && string.Equals(Key, other.Key, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Key.GetHashCode();
+
+    /// <summary>
+    /// Builds the diagnostic reported when this signature is produced more than once.
+    /// </summary>
+    /// <returns>A new <see cref="ReportedDiagnostic"/>.</returns>
+    public ReportedDiagnostic ToCollisionDiagnostic()
+        => new(DiagnosticMessages.CollidingOverloads, FilePath, TextSpan, LineSpan, Key);
+}

--- a/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
+++ b/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
@@ -74,14 +74,7 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
         var collidingSignatures = methodDeclarations
             .Select(static (m, _) => m.Signature?.Key)
             .Collect()
-            .Select(static (keys, _) => new EquatableArray<string>(
-            [
-                .. keys
-                    .Where(static key => key is not null)
-                    .GroupBy(static key => key!, StringComparer.Ordinal)
-                    .Where(static group => group.Count() > 1)
-                    .Select(static group => group.Key),
-            ]));
+            .Select(static (keys, _) => ToCollidingSignatures(keys));
 
         context.RegisterSourceOutput(
             sourceTexts.Combine(collidingSignatures),
@@ -143,6 +136,27 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
         return [];
 #else
         return ImmutableArray<TransformResult>.Empty;
+#endif
+    }
+
+    /// <summary>
+    /// Picks out the signatures produced by more than one method. Emitting all of them would
+    /// declare the same member twice.
+    /// </summary>
+    /// <param name="keys">Signature of every method being generated.</param>
+    /// <returns>The signatures which appear more than once.</returns>
+    private static EquatableArray<string> ToCollidingSignatures(ImmutableArray<string?> keys)
+    {
+        var colliding = keys
+            .Where(static key => key is not null)
+            .GroupBy(static key => key!, StringComparer.Ordinal)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key);
+
+#if ROSLYN_4_12_OR_GREATER
+        return new([.. colliding]);
+#else
+        return new(ImmutableArray.CreateRange(colliding));
 #endif
     }
 

--- a/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
+++ b/src/Zomp.SyncMethodGenerator/SyncMethodSourceGenerator.cs
@@ -69,13 +69,36 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
             .Select(static (m, _) => GenerateSource(m))
             .WithTrackingName("GenerateSource");
 
+        // Signatures produced more than once. Emitting them all would declare the same member
+        // twice, so the methods behind them are reported instead of generated.
+        var collidingSignatures = methodDeclarations
+            .Select(static (m, _) => m.Signature?.Key)
+            .Collect()
+            .Select(static (keys, _) => new EquatableArray<string>(
+            [
+                .. keys
+                    .Where(static key => key is not null)
+                    .GroupBy(static key => key!, StringComparer.Ordinal)
+                    .Where(static group => group.Count() > 1)
+                    .Select(static group => group.Key),
+            ]));
+
         context.RegisterSourceOutput(
-            sourceTexts,
-            static (spc, source) =>
+            sourceTexts.Combine(collidingSignatures),
+            static (spc, pair) =>
             {
+                var (source, colliding) = pair;
+
                 foreach (var diagnostic in source.MethodToGenerate.Diagnostics)
                 {
                     spc.ReportDiagnostic(diagnostic);
+                }
+
+                if (source.MethodToGenerate.Signature is { } signature
+                    && colliding.AsImmutableArray().Contains(signature.Key, StringComparer.Ordinal))
+                {
+                    spc.ReportDiagnostic(signature.ToCollisionDiagnostic());
+                    return;
                 }
 
                 if (!source.MethodToGenerate.HasErrors)
@@ -123,13 +146,19 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
 #endif
     }
 
+    /// <summary>
+    /// Names a containing type, keeping its type parameters so that <c>Class</c>, <c>Class{T}</c>
+    /// and <c>Class{T,T2}</c> stay distinct.
+    /// </summary>
+    /// <param name="c">The containing type.</param>
+    /// <returns>The name.</returns>
+    private static string BuildClassName(MethodParentDeclaration c)
+        => c.TypeParameterListSyntax.IsEmpty
+            ? c.ParentName
+            : c.ParentName + "{" + string.Join(",", c.TypeParameterListSyntax) + "}";
+
     private static (MethodToGenerate MethodToGenerate, string Path, string Content) GenerateSource(MethodToGenerate m)
     {
-        static string BuildClassName(MethodParentDeclaration c)
-            => c.TypeParameterListSyntax.IsEmpty
-                ? c.ParentName
-                : c.ParentName + "{" + string.Join(",", c.TypeParameterListSyntax) + "}";
-
         var scope = $"{string.Join(".", m.Namespaces)}" +
             $".{string.Join(".", m.Parents.Select(BuildClassName))}" +
             (m.IsCSharp14Extension ? ".ext" : string.Empty);
@@ -355,9 +384,52 @@ public class SyncMethodSourceGenerator : IIncrementalGenerator
 #else
         var isCSharp14Extension = false;
 #endif
-        var result = new MethodToGenerate(index, namespaces.ToImmutable(), isNamespaceFileScoped, isCSharp14Extension, classes.ToImmutable(), methodDeclarationSyntax.Identifier.ValueText, content, disableNullable, rewriter.Diagnostics, hasErrors);
+        var signature = BuildSignature(sn, namespaces, classes, methodDeclarationSyntax);
+
+        var result = new MethodToGenerate(index, namespaces.ToImmutable(), isNamespaceFileScoped, isCSharp14Extension, classes.ToImmutable(), methodDeclarationSyntax.Identifier.ValueText, content, disableNullable, rewriter.Diagnostics, hasErrors, signature);
 
         return result;
+    }
+
+    /// <summary>
+    /// Describes the method which is about to be emitted, precisely enough to tell whether two
+    /// of them would declare the same member. The rewritten declaration is used rather than the
+    /// original symbol, so the comparison sees exactly what the compiler will see - parameters
+    /// already dropped, types already substituted.
+    /// </summary>
+    /// <param name="rewritten">Result of rewriting the method.</param>
+    /// <param name="namespaces">Namespaces the method lives in.</param>
+    /// <param name="parents">Types the method is nested in.</param>
+    /// <param name="original">Method being synchronized, for the location to report against.</param>
+    /// <returns>The signature, or null when the rewritten method could not be located.</returns>
+    private static SynchronizedSignature? BuildSignature(
+        SyntaxNode rewritten,
+        ImmutableArray<string>.Builder namespaces,
+        ImmutableArray<MethodParentDeclaration>.Builder parents,
+        MethodDeclarationSyntax original)
+    {
+        var method = rewritten as MethodDeclarationSyntax
+            ?? rewritten.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+
+        if (method is null)
+        {
+            return null;
+        }
+
+        var scope = string.Join(".", namespaces.Concat(parents.Select(BuildClassName)));
+
+        // Arity by count rather than by name, since overloads which differ only in what they
+        // call their type parameters still declare the same member.
+        var arity = method.TypeParameterList?.Parameters.Count ?? 0;
+        var arityMarker = arity > 0 ? "`" + arity.ToString(System.Globalization.CultureInfo.InvariantCulture) : string.Empty;
+
+        var parameters = string.Join(",", method.ParameterList.Parameters.Select(static p => p.Type?.ToString() ?? string.Empty));
+
+        var key = $"{scope}.{method.Identifier.ValueText}{arityMarker}({parameters})";
+
+        var location = original.GetLocation();
+
+        return new(key, location.SourceTree?.FilePath ?? string.Empty, location.SourceSpan, location.GetLineSpan().Span);
     }
 
     internal sealed record TransformResult(GeneratorAttributeSyntaxContext Context, MethodDeclarationSyntax Syntax);

--- a/tests/Generator.Tests/Snapshots/UnitTests.ReportOverloadsWhichCollideWhenSynchronized.verified.txt
+++ b/tests/Generator.Tests/Snapshots/UnitTests.ReportOverloadsWhichCollideWhenSynchronized.verified.txt
@@ -1,0 +1,30 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: : (3,4)-(5,36),
+      Message: Cannot synchronize this overload. It produces 'Test.Class.Write(int)', which another overload in the same type also produces. Apply [SkipSyncVersion] to all but one of them.,
+      Severity: Error,
+      Descriptor: {
+        Id: ZSMGEN005,
+        Title: Overloads collide once synchronized,
+        MessageFormat: Cannot synchronize this overload. It produces '{0}', which another overload in the same type also produces. Apply [SkipSyncVersion] to all but one of them.,
+        Category: Usage,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    },
+    {
+      Location: : (7,4)-(9,36),
+      Message: Cannot synchronize this overload. It produces 'Test.Class.Write(int)', which another overload in the same type also produces. Apply [SkipSyncVersion] to all but one of them.,
+      Severity: Error,
+      Descriptor: {
+        Id: ZSMGEN005,
+        Title: Overloads collide once synchronized,
+        MessageFormat: Cannot synchronize this overload. It produces '{0}', which another overload in the same type also produces. Apply [SkipSyncVersion] to all but one of them.,
+        Category: Usage,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/tests/Generator.Tests/UnitTests.cs
+++ b/tests/Generator.Tests/UnitTests.cs
@@ -747,6 +747,17 @@ async Task ReadAsMemoryAsync(Stream stream, byte[] sampleBytes, int z)
 """.Verify();
 
     [Fact]
+    public Task ReportOverloadsWhichCollideWhenSynchronized() => """
+[CreateSyncVersion]
+async Task WriteAsync(int i, CancellationToken ct)
+    => await Task.CompletedTask;
+
+[CreateSyncVersion]
+async Task WriteAsync(int i)
+    => await Task.CompletedTask;
+""".Verify();
+
+    [Fact]
     public Task FindsASpan() => """
 class ClassThatReturnsMemoryAndSpan
 {


### PR DESCRIPTION
## Problem

Reported in #132. Two overloads which differ only in a parameter the rewriter removes produce the same member:

```cs
[CreateSyncVersion] async Task WriteAsync(int i, CancellationToken ct) => ...
[CreateSyncVersion] async Task WriteAsync(int i) => ...
```

Both become `void Write(int i)`. Hint names are disambiguated with an index, so both files are emitted happily and the user is left holding a `CS0111` pointing at generated code they never wrote.

## Fix

The signature is taken from the **rewritten** declaration rather than the original symbol, so the comparison sees exactly what the compiler will see - parameters already dropped, types already substituted. Signatures produced more than once are reported as `ZSMGEN005` and the methods behind them are not emitted, which keeps `CS0111` out of the picture entirely.

The message names the signature and says what to do:

```
error ZSMGEN005: Cannot synchronize this overload. It produces
'CsvHelper.CsvWriter.WriteRecords`1(global::System.Collections.Generic.IEnumerable<T>)',
which another overload in the same type also produces.
Apply [SkipSyncVersion] to all but one of them.
```

## Two details, both caught by existing tests rather than foresight

**The containing type keeps its type parameters in the key.** `Class`, `Class{T}` and `Class{T,T2}` are different types which may each hold a method of the same name; without this, `FileNameTests.DoNotCollideClassNames` reported three false collisions.

**The signature compares by key alone.** It carries the span of the method to report against, and spans shift whenever anything above the method is edited. Letting that into the incremental pipeline made a method whose generated output had not changed look modified, which `IncrementalGeneratorTests.CheckGeneratorIsIncremental` noticed immediately.

## Verified against a real adoption

Pointed at CsvHelper, where `WriteRecordsAsync<T>(IEnumerable<T>)` and `WriteRecordsAsync<T>(IAsyncEnumerable<T>)` both reduce to `WriteRecords<T>(IEnumerable<T>)`. The diagnostic fired on both overloads at their own locations; applying `[SkipSyncVersion]` to one, as the message suggests, produced a clean build across all seven of that project's target frameworks.

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)