### PR TITLE
Check that the package really was published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,10 +236,29 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_PUSH_KEY }}
 
+      - name: Create GitHub Release
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }} # gh infers the repo from this when no checkout is present
+        run: |
+          pkg=$(ls Zomp.SyncMethodGenerator.*.nupkg | head -1)
+          version=${pkg#Zomp.SyncMethodGenerator.}
+          version=${version%.nupkg}
+          gh release create "v$version" \
+            --target "$GITHUB_SHA" \
+            --title "v$version" \
+            --generate-notes \
+            ./*.nupkg
+
       # Accepting an upload is not the same as publishing it. NuGet validates the signature and
       # scans the package afterwards, and only then can anyone install it, so the push
-      # succeeding on its own says very little. Waiting here also keeps the tag and the release
-      # from pointing at a version which never became installable.
+      # succeeding on its own says very little.
+      #
+      # This runs last and gates nothing. The tag records which commit was built and the release
+      # carries the package as an asset, both of which hold whatever NuGet decides. Waiting first
+      # would mean that validation merely being slow, which is far more common than validation
+      # failing, left the package published with no tag and no release to go with it.
       - name: Wait for NuGet to finish validating
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: |
@@ -259,18 +278,3 @@ jobs:
 
           echo "::error::$version was accepted by NuGet but has not become available within 20 minutes. See https://www.nuget.org/packages/Zomp.SyncMethodGenerator/$version"
           exit 1
-
-      - name: Create GitHub Release
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }} # gh infers the repo from this when no checkout is present
-        run: |
-          pkg=$(ls Zomp.SyncMethodGenerator.*.nupkg | head -1)
-          version=${pkg#Zomp.SyncMethodGenerator.}
-          version=${version%.nupkg}
-          gh release create "v$version" \
-            --target "$GITHUB_SHA" \
-            --title "v$version" \
-            --generate-notes \
-            ./*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,15 @@ jobs:
           --trusted-signing-certificate-profile "${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}" \
           -v normal
 
+      # Catches a signing step which quietly produced nothing usable, while the package can
+      # still be thrown away. Runs here rather than after publishing because Windows is where
+      # signature verification needs no extra setup.
+      - name: Verify signature
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_SIGNER_CLIENT_SECRET }}
+        if: ${{ env.AZURE_CLIENT_SECRET != '' && github.ref == 'refs/heads/master' }}
+        run: dotnet nuget verify "${{ github.workspace }}/packages/"*.nupkg --all
+
       - name: Upload artifacts (.nupkg)
         uses: actions/upload-artifact@v5
         with:
@@ -226,6 +235,30 @@ jobs:
       - name: Push to NuGet
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_PUSH_KEY }}
+
+      # Accepting an upload is not the same as publishing it. NuGet validates the signature and
+      # scans the package afterwards, and only then can anyone install it, so the push
+      # succeeding on its own says very little. Waiting here also keeps the tag and the release
+      # from pointing at a version which never became installable.
+      - name: Wait for NuGet to finish validating
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
+        run: |
+          pkg=$(ls Zomp.SyncMethodGenerator.*.nupkg | head -1)
+          version=${pkg#Zomp.SyncMethodGenerator.}
+          version=${version%.nupkg}
+          index=https://api.nuget.org/v3-flatcontainer/zomp.syncmethodgenerator/index.json
+
+          for _ in $(seq 1 40); do
+            if curl -s "$index" | grep -q "\"$version\""; then
+              echo "$version is available on NuGet"
+              exit 0
+            fi
+
+            sleep 30
+          done
+
+          echo "::error::$version was accepted by NuGet but has not become available within 20 minutes. See https://www.nuget.org/packages/Zomp.SyncMethodGenerator/$version"
+          exit 1
 
       - name: Create GitHub Release
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Why

A successful `dotnet nuget push` means NuGet **accepted the upload**, not that anyone can install the result. Signature validation and scanning happen afterwards, and only then does the package become downloadable.

This is not hypothetical - it is what 2.0.33 did. The workflow went fully green (push succeeded, tag created, release published) while the package sat in `Validating` and `dotnet add package` would have failed. Had validation *rejected* it, the only signal would have been an email.

## What this adds

**Verify the signature, in the `sign` job**, right after signing, while the package can still be thrown away:

```yaml
- name: Verify signature
  run: dotnet nuget verify "${{ github.workspace }}/packages/"*.nupkg --all
```

It runs there rather than after publishing because that job is on `windows-latest`, where signature verification needs no extra setup - on Linux it wants `DOTNET_NUGET_SIGNATURE_VERIFICATION` and trusted roots. Gated on the same condition as signing, so pull requests, where nothing is signed, are unaffected.

**Wait for validation, in the `publish` job, last.** It polls the flat container index for the published version for up to twenty minutes, and fails with the version and a link if it never appears.

## Why the wait runs after the tag rather than before

The first version of this gated the tag and release on validation, on the reasoning that a tag pointing at an uninstallable version is worse than no tag. That reasoning only holds if the wait failing means validation *rejected* the package, and it conflates two quite different failures:

- **Validation rejects the package.** Rare. Leaves a release for an uninstallable version; cleanup is `gh release delete` plus deleting the tag, and the build is red so you know to do it.
- **Validation is slow** and exceeds the window. Considerably more likely. Gating on it leaves the package published on NuGet with no tag and no release, which has to be repaired by hand with the right target commit, notes and assets - exactly the work this automation exists to avoid.

The more likely failure had the worse recovery, so the order is now push, tag and release, then wait. The wait gates nothing; it turns "the package never became installable" from an email nobody reads into a failed build. The tag records which commit was built and the release carries the package as an asset, both of which hold regardless of what NuGet decides.

## Verification

The polling logic was checked against the live endpoint, including the substring case it could plausibly get wrong: matching on the quoted version means `2.0.3` cannot match inside `2.0.32`. (`2.0.3` does report as found - it is a genuinely published version.)

Neither step can run on this pull request: both are gated on `master`, and the wait is `workflow_dispatch` only. They will first execute on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)