### PR TITLE
Hold the release as a draft until the package validates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,13 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_PUSH_KEY }}
 
-      - name: Create GitHub Release
+      # Prepared but not announced. NuGet has accepted the upload at this point and nothing
+      # more; it still validates the signature and scans the package, and a package whose
+      # certificate is not registered with the account is rejected at that stage. Announcing a
+      # version which turns out to be uninstallable is worse than announcing it a few minutes
+      # later, and building the release now means a slow validation costs a single command
+      # rather than reconstructing the notes and assets by hand.
+      - name: Draft GitHub Release
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -246,19 +252,12 @@ jobs:
           version=${pkg#Zomp.SyncMethodGenerator.}
           version=${version%.nupkg}
           gh release create "v$version" \
+            --draft \
             --target "$GITHUB_SHA" \
             --title "v$version" \
             --generate-notes \
             ./*.nupkg
 
-      # Accepting an upload is not the same as publishing it. NuGet validates the signature and
-      # scans the package afterwards, and only then can anyone install it, so the push
-      # succeeding on its own says very little.
-      #
-      # This runs last and gates nothing. The tag records which commit was built and the release
-      # carries the package as an asset, both of which hold whatever NuGet decides. Waiting first
-      # would mean that validation merely being slow, which is far more common than validation
-      # failing, left the package published with no tag and no release to go with it.
       - name: Wait for NuGet to finish validating
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
         run: |
@@ -276,5 +275,18 @@ jobs:
             sleep 30
           done
 
-          echo "::error::$version was accepted by NuGet but has not become available within 20 minutes. See https://www.nuget.org/packages/Zomp.SyncMethodGenerator/$version"
+          echo "::error::$version was accepted by NuGet but has not become available within 20 minutes. The release is drafted and can be published once it appears. See https://www.nuget.org/packages/Zomp.SyncMethodGenerator/$version"
           exit 1
+
+      # The package is installable, so the release can be announced. This is also what creates
+      # the tag, which a draft release holds but does not push.
+      - name: Publish GitHub Release
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          pkg=$(ls Zomp.SyncMethodGenerator.*.nupkg | head -1)
+          version=${pkg#Zomp.SyncMethodGenerator.}
+          version=${version%.nupkg}
+          gh release edit "v$version" --draft=false


### PR DESCRIPTION
## Why

NuGet accepting an upload is not the same as accepting the package. It validates the signature afterwards, and **a package signed with a certificate which is not registered with the account is rejected at that point**. Until now the release was announced before any of that was known, so a rejected package would have left a public GitHub Release for a version nobody could install.

The certificate is registered today - 2.0.32, 2.0.33 and 2.0.35 all validated - so this is about certificate rotation and expiry, which is exactly when nobody is expecting it.

## What changes

```
Push to NuGet  ->  draft the release  ->  wait for validation  ->  publish the release
```

- `gh release create --draft` builds the release with its generated notes and the `.nupkg` attached, but announces nothing.
- The existing wait polls until the version is installable.
- `gh release edit --draft=false` then announces it, which is also what pushes the tag.

## Why not simply move the wait before the release

That was the first instinct and it is worse, because it treats two very different failures the same way:

- **Validation rejects the package.** Rare. With the draft, nothing was ever announced and there is no tag - delete the draft and move on.
- **Validation is slow** and exceeds the window. Considerably more likely. Waiting first would leave the package published with no release at all, to be rebuilt by hand with the right target commit, notes and assets. With the draft, everything already exists and publishing it is a single command.

Drafting first is the only arrangement where neither failure requires reconstructing anything.

Worth knowing: a draft release holds its tag rather than pushing it, so on the failing path there is no tag either. For a version which never became installable, that is the right outcome.

## Verification

Cannot run on this pull request - the steps are gated on `master` and `workflow_dispatch`. The release after this merges is their first exercise, as was the case for the verify and wait steps added in #143, which both succeeded on 2.0.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)