### PR TITLE
Sign on Linux instead of Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,40 +128,17 @@ jobs:
     # Skip for outside contributors: fork PRs have no access to signing/publish
     # secrets, so the release pipeline can't do anything useful for them.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: Set path for nektos/act
-        if: ${{ runner.os == 'Windows' && env.ACT }}
-        run: echo "C:\Program Files\Git\bin" >> $GITHUB_PATH
-        shell: '"C:\Program Files\Git\bin\bash.exe" -c {0}'
-
-      - name: "Determine prerequisites"
-        id: prerequisite
-        run: |
-          echo "need_node=$(command -v node >/dev/null 2>&1 && echo 0 || echo 1)" >> $GITHUB_OUTPUT
-
       - name: Setup .NET
-        if: ${{ runner.os != 'Windows' || !env.ACT }}
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             10.0.x
-
-      - name: Install node
-        if: ${{ steps.prerequisite.outputs.need_node == '1' }}
-        run: |
-          if [ "${{ runner.os }}" = "windows" ]
-          then
-            choco install nodejs -y
-            echo "C:\Program Files\nodejs" >> $GITHUB_PATH
-          else
-            curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&\
-            apt-get install -y nodejs
-          fi
 
       - name: Download Package artifact
         uses: actions/download-artifact@v5
@@ -169,29 +146,39 @@ jobs:
           name: packages
           path: packages
 
+      # Pinned deliberately: the tool that signs the release should not change without
+      # someone choosing to change it.
+      - name: Install the signing tool
+        run: dotnet tool install --global SignUniversal --version 1.0.26-alpha
+
       - name: Sign
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_SIGNER_CLIENT_SECRET }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_SIGNER_CLIENT_ID }}
         if: ${{ env.AZURE_CLIENT_SECRET != '' && github.ref == 'refs/heads/master' }}
+        # --trust-signing-root is required on Linux and its absence is not obvious. Trusted
+        # Signing issues from Microsoft Identity Verification Root CA 2020, which Linux trust
+        # stores do not carry, and NuGet refuses to sign against a chain it cannot build:
+        # without the flag this step fails with only "Certificate chain validation failed".
+        # The root is installed for this user alone, from the chain the signing service
+        # itself returned.
         run: |
-          dotnet dnx --prerelease --yes sign code trusted-signing \
-          --base-directory "${{ github.workspace }}/packages" \
-          "*.nupkg" \
-          --trusted-signing-endpoint "${{ secrets.TRUSTED_SIGNING_ENDPOINT }}" \
-          --trusted-signing-account "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}" \
-          --trusted-signing-certificate-profile "${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}" \
-          -v normal
+          sign-universal sign packages/*.nupkg --trust-signing-root \
+            --trusted-signing-endpoint "${{ secrets.TRUSTED_SIGNING_ENDPOINT }}" \
+            --trusted-signing-account "${{ secrets.TRUSTED_SIGNING_ACCOUNT }}" \
+            --trusted-signing-certificate-profile "${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}"
 
       # Catches a signing step which quietly produced nothing usable, while the package can
-      # still be thrown away. Runs here rather than after publishing because Windows is where
-      # signature verification needs no extra setup.
+      # still be thrown away. dotnet nuget verify is cross-platform, so this needs nothing
+      # Windows-specific: a real Trusted Signing certificate chains to a root in NuGet's own
+      # bundle, so anything short of a clean pass means nobody downstream could validate the
+      # package either.
       - name: Verify signature
         env:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_SIGNER_CLIENT_SECRET }}
         if: ${{ env.AZURE_CLIENT_SECRET != '' && github.ref == 'refs/heads/master' }}
-        run: dotnet nuget verify "${{ github.workspace }}/packages/"*.nupkg --all
+        run: dotnet nuget verify packages/*.nupkg --all
 
       - name: Upload artifacts (.nupkg)
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
Moves the `sign` job from `windows-latest` to `ubuntu-latest`.

The Windows runner was there for one reason: `dotnet sign` supports Trusted Signing but
cannot run anywhere else - its backend, `Microsoft.Trusted.Signing.Client`, ships a native
signtool Dlib with MFC/MSVC dependencies. `dotnet nuget sign` runs anywhere but only with a
local private key, which a key in Trusted Signing does not have.

[sign-universal](https://github.com/zompinc/sign-universal) closes that gap: NuGet's own
signing pipeline with the private-key operation redirected to Trusted Signing over HTTPS.

**Nothing else changes.** The job keeps its name, inputs and outputs, `publish` still
consumes `packages-signed`, and the signatures are ordinary NuGet author signatures - a
package signed either way is indistinguishable to consumers. The node install and the
nektos/act path shim go away with Windows.

### Verified before proposing

The exact command in this job, run against `Zomp.SyncMethodGenerator 2.0.38` on Linux with
the real credentials:

```
Signed Zomp.SyncMethodGenerator.2.0.38.nupkg
  signature: author, SHA256
  timestamp: http://timestamp.digicert.com/

dotnet nuget verify --all -> exit 0
  Signature type: Author
  Subject Name: CN=Zomp Inc., O=Zomp Inc., L=Toronto, S=Ontario, C=CA
```

### Two things worth knowing

`--trust-signing-root` is **required** on Linux and its absence is not obvious. Trusted
Signing issues from *Microsoft Identity Verification Root CA 2020*, which Linux trust
stores do not carry, and NuGet validates the signing certificate's chain before it will
sign. Without the flag the step fails with only `Certificate chain validation failed`. The
root is installed for that user alone, taken from the chain the signing service itself
returned.

The tool version is **pinned**. The thing signing a release should not change unless
someone chooses to change it.

### What this PR cannot prove

The `Sign` and `Verify signature` steps are gated on `github.ref == 'refs/heads/master'`,
so they do not run here - CI will only show that the job's structure is sound and the tool
installs. Signing itself first executes on the next push to master. It fails loudly rather
than silently if anything is wrong: the verify step gates the artifact while it can still
be thrown away.

Rolling back is reverting this commit.