### PR TITLE
Use the renamed signing tool package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
       # Pinned deliberately: the tool that signs the release should not change without
       # someone choosing to change it.
       - name: Install the signing tool
-        run: dotnet tool install --global SignUniversal --version 1.0.26-alpha
+        run: dotnet tool install --global SignUniversal.Cli --version 1.0.31-alpha
 
       - name: Sign
         env:


### PR DESCRIPTION
`sign-universal` split its engine into a library so other tools can embed it. The library took the `SignUniversal` name and the dotnet tool moved to `SignUniversal.Cli`, first released as `1.0.31-alpha`.

Same tool, same `sign-universal` command, same flags - only the package id and the pin change. The old pin still restores, so this is not urgent, but leaving it means the next version bump has to change the id anyway.

Verified from nuget.org before opening: `dotnet dnx SignUniversal.Cli@1.0.31-alpha -- --version` reports `1.0.31-alpha+1ef896295f`.