### PR TITLE
Point at SharpCompress as a worked example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This [.NET source generator](https://learn.microsoft.com/en-us/dotnet/csharp/ros
   - Large data from I/O which cannot be stored in memory before processing: Original async method
   - Small sample of data in memory, usually a sample of the larger data: Generated sync method
 
+## Used by
+
+[SharpCompress](https://github.com/adamhathcock/sharpcompress), a compression library for .NET, generates its synchronous methods this way.
+
+Its [migration notes](https://github.com/adamhathcock/sharpcompress/blob/master/docs/SYNC_METHOD_GENERATION.md) are worth reading before adopting this in a codebase which already has both halves written by hand. They cover how to prove that a generated method is the one it replaces, and when attributing a method would add a member rather than remove a duplicate - a generated `Read(Span<byte>)` displaces the shim `Stream` provides, which is a change in behaviour rather than a deduplication.
+
 ## How it works
 
 ### CreateSyncVersionAttribute on a method

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ This [.NET source generator](https://learn.microsoft.com/en-us/dotnet/csharp/ros
 
 ## Used by
 
-[SharpCompress](https://github.com/adamhathcock/sharpcompress), a compression library for .NET, generates its synchronous methods this way.
+- [FluentValidation](https://github.com/FluentValidation/FluentValidation) - validation library
+- [MiniExcel](https://github.com/mini-software/MiniExcel) - spreadsheet reader and writer
+- [SharpCompress](https://github.com/adamhathcock/sharpcompress) - compression library
 
-Its [migration notes](https://github.com/adamhathcock/sharpcompress/blob/master/docs/SYNC_METHOD_GENERATION.md) are worth reading before adopting this in a codebase which already has both halves written by hand. They cover how to prove that a generated method is the one it replaces, and when attributing a method would add a member rather than remove a duplicate - a generated `Read(Span<byte>)` displaces the shim `Stream` provides, which is a change in behaviour rather than a deduplication.
+SharpCompress's [migration notes](https://github.com/adamhathcock/sharpcompress/blob/master/docs/SYNC_METHOD_GENERATION.md) are worth reading before adopting this in a codebase which already has both halves written by hand. They cover how to prove that a generated method is the one it replaces, and when attributing a method would add a member rather than remove a duplicate - a generated `Read(Span<byte>)` displaces the shim `Stream` provides, which is a change in behaviour rather than a deduplication.
 
 ## How it works
 


### PR DESCRIPTION
[SharpCompress](https://github.com/adamhathcock/sharpcompress) generates its synchronous methods with this generator as of [#1381](https://github.com/adamhathcock/sharpcompress/pull/1381) and [#1383](https://github.com/adamhathcock/sharpcompress/pull/1383).

Worth linking for the [migration notes](https://github.com/adamhathcock/sharpcompress/blob/master/docs/SYNC_METHOD_GENERATION.md) written while converting it, which answer the questions someone adopting this in a codebase that already has both halves written by hand actually has, and which this repository's own documentation does not:

- how to prove a generated method is the one it replaced - build with `EmitCompilerGeneratedFiles`, diff each generated body against the one deleted from a baseline commit, expect an empty diff
- when attributing a method adds a member rather than removing a duplicate. A generated `Read(Span<byte>)` displaces the shim `Stream` provides, which is a change in behaviour rather than a deduplication
- that only the active syntax for the current compilation is seen, so a codebase with `#if` around framework differences has to be checked in both worlds

🤖 Generated with [Claude Code](https://claude.com/claude-code)