### PR TITLE
Sign with the 1.0 release of the signing tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
       # Pinned deliberately: the tool that signs the release should not change without
       # someone choosing to change it.
       - name: Install the signing tool
-        run: dotnet tool install --global SignUniversal.Cli --version 1.0.31-alpha
+        run: dotnet tool install --global SignUniversal.Cli --version 1.0.32
 
       - name: Sign
         env:


### PR DESCRIPTION
`sign-universal` dropped its alpha suffix. `1.0.32` is the first stable release - same tool, same `sign-universal` command, same flags.

Verified before opening: `dotnet dnx SignUniversal.Cli -- --version` (no version, no `--prerelease`) resolves `1.0.32+dde324a35c`, matching the release commit.