### PR TITLE
Install the marketplace with a sparse checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,11 @@ dotnet add package Zomp.SyncMethodGenerator
 This repository is also a [Claude Code](https://claude.com/claude-code) marketplace. Installing the plugin teaches the agent to reach for this generator when it finds itself writing or maintaining both halves of a sync/async pair, rather than duplicating the method by hand.
 
 ```sh
-claude plugin marketplace add zompinc/sync-method-generator
+claude plugin marketplace add zompinc/sync-method-generator --sparse .claude-plugin plugins
 claude plugin install sync-method-generator@zomp
 ```
+
+`--sparse` checks out only the two directories the marketplace needs. It is worth passing everywhere for the smaller clone, and is required on Windows, where the snapshot file names under `tests/Generator.Tests/Snapshots` carry a full checkout past the 260 character path limit.
 
 The plugin ships a single skill covering setup, the attribute options, the transformation table, and how to verify that a generated method is the hand-written one it replaces.
 


### PR DESCRIPTION
Follow-up to #159. The install command it published does not work on Windows, which I did not catch because I verified the plugin from a local path rather than from GitHub.

Adding a marketplace clones the whole repository. The verified snapshot file names run to 199 characters before the clone root is counted, so a full checkout lands past the 260 character limit:

```
error: unable to create file tests/Generator.Tests/Snapshots/FileNameTests.ShortenLongFileNameWhenTheMethodNameFillsIt#_b60220f2.ThisMethodHasAnUnreasonablyLongNameWhichOnItsOwnLeavesNoRoomForTheNamespaceOrTheConta.g.verified.cs: Filename too long
fatal: unable to checkout working tree
```

The clone succeeds, the checkout fails, and the marketplace never registers. `claude plugin marketplace add` takes `--sparse`, which limits the checkout to named directories:

```sh
claude plugin marketplace add zompinc/sync-method-generator --sparse .claude-plugin plugins
claude plugin install sync-method-generator@zomp
```

Verified end to end from GitHub on Windows with this form: marketplace registers, plugin installs, `claude plugin details` lists the skill. Worth passing on Linux and macOS too, where the alternative is cloning the whole test corpus to obtain four small files.

Note that the repository itself still needs `core.longpaths` to clone on Windows - the local clone here has it set in `.git/config`, which is why this never showed up during development. Anyone cloning fresh without it gets a broken checkout. That is a separate problem and this does not fix it.