### PR TITLE
Offer the plugin to anyone working in this repository

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "zomp": {
+      "source": {
+        "source": "github",
+        "repo": "zompinc/sync-method-generator",
+        "sparsePaths": [".claude-plugin", "plugins"]
+      }
+    }
+  },
+  "enabledPlugins": {
+    "sync-method-generator@zomp": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,17 @@ remove the limit.
 Consumers installing the Claude Code plugin are unaffected, the documented
 install command using a sparse checkout which never touches the snapshots.
 
+## Claude Code plugin
+
+`.claude/settings.json` declares this repository as a plugin marketplace and
+enables the `sync-method-generator` plugin at project scope, so Claude Code
+offers the skill to anyone working here. The skill lives in
+`plugins/sync-method-generator/skills/sync-from-async` and is the same one
+consumers install; editing it and reloading is how to try a change.
+
+Declining the plugin costs nothing. It contributes a skill and no hooks, agents
+or MCP servers.
+
 ## Build & Test
 
 ```bash


### PR DESCRIPTION
There is no plugin search in Claude Code - installing one requires knowing the owner and repository already, so #159 shipped something nobody can stumble into. Project scope is the way around that. A committed `.claude/settings.json` declares the marketplace and enables the plugin for everyone who opens the repository, with no prior knowledge needed on their part.

```json
{
  "extraKnownMarketplaces": {
    "zomp": {
      "source": {
        "source": "github",
        "repo": "zompinc/sync-method-generator",
        "sparsePaths": [".claude-plugin", "plugins"]
      }
    }
  },
  "enabledPlugins": {
    "sync-method-generator@zomp": true
  }
}
```

Contributors here are the obvious first case: someone working on the rewriter is the person best placed to notice that the skill describing it has gone stale. The sparse paths are recorded in the settings, so their marketplace clone works on Windows without anyone needing to know about #160.

`AGENTS.md` gains a short note saying what the file is and that declining costs nothing - the plugin contributes one skill and no hooks, agents or MCP servers.

The same two-line change in an adopter repository would reach a much larger audience, every contributor to it being someone already working in a codebase which uses the generator. Worth asking those maintainers before assuming it is welcome rather than opening PRs at them.