### PR TITLE
Keep the break which follows an opening parenthesis

### DIFF
--- a/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
+++ b/src/Zomp.SyncMethodGenerator/AsyncToSyncRewriter.cs
@@ -1159,9 +1159,14 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
 
         if (invalid.Contains(node.Arguments.Count - 1))
         {
-            retval = retval
-                .WithCloseParenToken(@base.CloseParenToken.WithLeadingTrivia())
-                .WithOpenParenToken(@base.OpenParenToken.WithTrailingTrivia());
+            retval = retval.WithCloseParenToken(@base.CloseParenToken.WithLeadingTrivia());
+
+            // The newline which followed the opening parenthesis belongs to whichever argument
+            // now comes first, so it only goes when nothing is left to put on that line.
+            if (newParams.Count == 0)
+            {
+                retval = retval.WithOpenParenToken(@base.OpenParenToken.WithTrailingTrivia());
+            }
         }
 
         return retval;
@@ -2021,23 +2026,40 @@ internal sealed class AsyncToSyncRewriter(SemanticModel semanticModel, bool disa
         var arguments = ies.ArgumentList.Arguments;
         var separators = arguments.GetSeparators();
 
+        // A list broken after its opening parenthesis gives each argument a line of its own. The
+        // receiver is about to become the first of them, so it wants the line the argument it
+        // displaces was starting, rather than the one the parenthesis is on.
+        var lineBreak = ies.ArgumentList.OpenParenToken.TrailingTrivia
+            .LastOrDefault(static t => t.IsKind(SyntaxKind.EndOfLineTrivia));
+        var brokenAfterOpenParen = lineBreak != default;
+
         SyntaxToken[] newSeparators = arguments.Count < 1 ? []
-            : [Token(SyntaxKind.CommaToken).AppendSpace(), .. separators];
+            : [brokenAfterOpenParen
+                ? Token(SyntaxKind.CommaToken).WithTrailingTrivia(lineBreak)
+                : Token(SyntaxKind.CommaToken).AppendSpace(), .. separators];
 
         // The receiver becomes the first argument, so whatever separated it from the dot - a
         // line break in a chained call - would otherwise land between it and the comma which
         // now follows.
         var @as = Argument(expression.WithoutTrivia());
 
-        // The argument the receiver displaces is no longer the first thing on its line, so
-        // indentation which was written to place it at the start of one only leaves a gap after
-        // the comma. Indentation which still follows a line break is left alone.
+        // The argument the receiver displaces either keeps the line it was starting, in which
+        // case the receiver takes its indentation and the comma between them takes the break, or
+        // it no longer starts one, in which case indentation written to place it at the start of
+        // a line only leaves a gap after the comma.
         List<ArgumentSyntax> newArguments = [.. arguments];
         if (newArguments is [var displaced, ..]
             && displaced.GetLeadingTrivia() is { Count: > 0 } leading
             && leading.All(static t => t.IsKind(SyntaxKind.WhitespaceTrivia)))
         {
-            newArguments[0] = displaced.WithoutLeadingTrivia();
+            if (brokenAfterOpenParen)
+            {
+                @as = @as.WithLeadingTrivia(leading);
+            }
+            else
+            {
+                newArguments[0] = displaced.WithoutLeadingTrivia();
+            }
         }
 
         var newList = SeparatedList([@as, .. newArguments], newSeparators);

--- a/tests/Generator.Tests/ArgumentTests.cs
+++ b/tests/Generator.Tests/ArgumentTests.cs
@@ -28,4 +28,21 @@ public async Task CallProgressMethodAsync()
     await ProgressMethodAsync(progress: null);
 }
 """.Verify();
+
+    [Fact]
+    public Task KeepLineBreaksWhenTheLastArgumentIsDropped() => """
+public void ProgressMethod(int p1, int p2) { }
+
+public async Task ProgressMethodAsync(int p1, int p2, CancellationToken cancellationToken) => await Task.CompletedTask;
+
+[Zomp.SyncMethodGenerator.CreateSyncVersion]
+public async Task CallProgressMethodAsync(CancellationToken cancellationToken)
+{
+    await ProgressMethodAsync(
+        1,
+        2,
+        cancellationToken
+    );
+}
+""".Verify();
 }

--- a/tests/Generator.Tests/ExtensionMethodTests.cs
+++ b/tests/Generator.Tests/ExtensionMethodTests.cs
@@ -215,7 +215,7 @@ public static partial class StreamExtensions
 
 #if NET8_0_OR_GREATER
     [Fact]
-    public Task CSharp_14_ExtensionUnwrapsOntoOneLine() => """
+    public Task CSharp_14_ExtensionDropsTheChainBreakAfterTheReceiver() => """
 namespace Helpers
 {
     internal static partial class StreamExtensions

--- a/tests/Generator.Tests/Snapshots/ArgumentTests.KeepLineBreaksWhenTheLastArgumentIsDropped#CallProgressMethodAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/ArgumentTests.KeepLineBreaksWhenTheLastArgumentIsDropped#CallProgressMethodAsync.g.verified.cs
@@ -1,0 +1,7 @@
+﻿//HintName: Test.Class.CallProgressMethodAsync.g.cs
+public void CallProgressMethod()
+{
+    ProgressMethod(
+        1,
+        2);
+}

--- a/tests/Generator.Tests/Snapshots/ExtensionMethodTests.CSharp_14_ExtensionDropsTheChainBreakAfterTheReceiver#Callers.StreamCallers.ext.DrainTwiceAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/ExtensionMethodTests.CSharp_14_ExtensionDropsTheChainBreakAfterTheReceiver#Callers.StreamCallers.ext.DrainTwiceAsync.g.verified.cs
@@ -10,7 +10,9 @@ namespace Callers
         extension(global::System.IO.Stream stream)
         {
             public void DrainTwice() =>
-                global::Helpers.StreamExtensions.Drain(stream, 1024);
+                global::Helpers.StreamExtensions.Drain(
+                        stream,
+                        1024);
         }
     }
 }

--- a/tests/Generator.Tests/Snapshots/ExtensionMethodTests.CSharp_14_ExtensionKeepsRemainingArgumentsOnTheirLines#Callers.StreamCallers.ext.CopyAsync.g.verified.cs
+++ b/tests/Generator.Tests/Snapshots/ExtensionMethodTests.CSharp_14_ExtensionKeepsRemainingArgumentsOnTheirLines#Callers.StreamCallers.ext.CopyAsync.g.verified.cs
@@ -13,7 +13,9 @@ namespace Callers
                 global::System.IO.Stream destination,
                 global::System.IProgress<int>? progress = null
             ) =>
-                global::Helpers.StreamExtensions.WriteTo(stream, destination,
+                global::Helpers.StreamExtensions.WriteTo(
+                        stream,
+                        destination,
                         4096,
                         progress: progress);
         }


### PR DESCRIPTION
Closes #152.

The issue's remaining item was the line break before the first argument, which the analysis there said was already gone from the syntax tree by the time `UnwrapExtension` ran, cause unlocated. It is `VisitArgumentList`:

```csharp
if (invalid.Contains(node.Arguments.Count - 1))
{
    retval = retval
        .WithCloseParenToken(@base.CloseParenToken.WithLeadingTrivia())
        .WithOpenParenToken(@base.OpenParenToken.WithTrailingTrivia());
}
```

Roslyn puts the newline that follows a token in that token's *trailing* trivia, so stripping the opening parenthesis's trailing trivia is stripping the break after `(`. That is right when the list empties - `(` and `)` should meet - but the condition is only that the *last* argument went, which is every call ending in a `CancellationToken`. So the break went, and the first argument kept the indentation which had placed it at the start of a line:

```cs
ProgressMethod(            1,
    2);
```

Now it is stripped only when nothing remains to put on that line. `ArgumentTests.KeepLineBreaksWhenTheLastArgumentIsDropped` covers this with no extension methods involved, which is where the bug actually lives.

That in turn unblocks the half of `UnwrapExtension` which #152 recorded as not working. With the list still broken where it was written to break, the receiver can take the line the argument it displaces was starting, and the comma between them can take the break:

```diff
-WriteTo(stream, destination,
+WriteTo(
+        stream,
+        destination,
         4096,
         progress: progress);
```

## One test changes meaning

`CSharp_14_ExtensionUnwrapsOntoOneLine` asserted that a two argument call collapsed onto a single line. That was never designed - #150 added the test to cover the receiver's own trivia, and the collapsing came from this bug removing a break the author had written. The generator preserves the layout it is given everywhere else, so preserving it here too is the consistent answer, and the test is renamed to `CSharp_14_ExtensionDropsTheChainBreakAfterTheReceiver` to say what it was built to cover.

If you would rather short lists collapse, that is a formatting decision the generator does not currently make anywhere, and worth its own issue rather than resting on this bug.

337 tests pass on net10.0, 295 on net472, clean build.